### PR TITLE
Fix ItemData hash code

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/ItemData.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/ItemData.java
@@ -57,7 +57,7 @@ public final class ItemData {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, damage, tag, canPlace, canBreak, blockingTicks);
+        return Objects.hash(id, damage, count, tag, Arrays.hashCode(canPlace), Arrays.hashCode(canBreak), blockingTicks);
     }
 
     public boolean equals(ItemData other, boolean checkAmount, boolean checkMetadata, boolean checkUserdata) {


### PR DESCRIPTION
Equal ItemData objects were returning different hash codes.