### PR TITLE
Fixed wrong multiplier for position in PlaySoundSerializer

### DIFF
--- a/bedrock/bedrock-v291/src/main/java/com/nukkitx/protocol/bedrock/v291/serializer/PlaySoundSerializer_v291.java
+++ b/bedrock/bedrock-v291/src/main/java/com/nukkitx/protocol/bedrock/v291/serializer/PlaySoundSerializer_v291.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v291 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }

--- a/bedrock/bedrock-v313/src/main/java/com/nukkitx/protocol/bedrock/v313/serializer/PlaySoundSerializer_v313.java
+++ b/bedrock/bedrock-v313/src/main/java/com/nukkitx/protocol/bedrock/v313/serializer/PlaySoundSerializer_v313.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v313 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }

--- a/bedrock/bedrock-v332/src/main/java/com/nukkitx/protocol/bedrock/v332/serializer/PlaySoundSerializer_v332.java
+++ b/bedrock/bedrock-v332/src/main/java/com/nukkitx/protocol/bedrock/v332/serializer/PlaySoundSerializer_v332.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v332 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }

--- a/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/serializer/PlaySoundSerializer_v340.java
+++ b/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/serializer/PlaySoundSerializer_v340.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v340 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }

--- a/bedrock/bedrock-v354/src/main/java/com/nukkitx/protocol/bedrock/v354/serializer/PlaySoundSerializer_v354.java
+++ b/bedrock/bedrock-v354/src/main/java/com/nukkitx/protocol/bedrock/v354/serializer/PlaySoundSerializer_v354.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v354 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }

--- a/bedrock/bedrock-v361/src/main/java/com/nukkitx/protocol/bedrock/v361/serializer/PlaySoundSerializer_v361.java
+++ b/bedrock/bedrock-v361/src/main/java/com/nukkitx/protocol/bedrock/v361/serializer/PlaySoundSerializer_v361.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v361 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }

--- a/bedrock/bedrock-v388/src/main/java/com/nukkitx/protocol/bedrock/v388/serializer/PlaySoundSerializer_v388.java
+++ b/bedrock/bedrock-v388/src/main/java/com/nukkitx/protocol/bedrock/v388/serializer/PlaySoundSerializer_v388.java
@@ -15,7 +15,7 @@ public class PlaySoundSerializer_v388 implements PacketSerializer<PlaySoundPacke
     @Override
     public void serialize(ByteBuf buffer, PlaySoundPacket packet) {
         BedrockUtils.writeString(buffer, packet.getSound());
-        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(3).toInt());
+        BedrockUtils.writeBlockPosition(buffer, packet.getPosition().mul(8).toInt());
         buffer.writeFloatLE(packet.getVolume());
         buffer.writeFloatLE(packet.getPitch());
     }


### PR DESCRIPTION
FIxes PlaySoundPacket serialization.

why 3, lol, it must be 8