### PR TITLE
New and old skin names in PlayerSkinPacket for v388-v390

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/PlayerSkinPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/PlayerSkinPacket.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 public class PlayerSkinPacket extends BedrockPacket {
     private UUID uuid;
     private SerializedSkin skin;
+    private String oldSkinName;
+    private String newSkinName;
     private boolean trustedSkin;
 
     @Override

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/PlayerSkinPacket.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/packet/PlayerSkinPacket.java
@@ -14,8 +14,8 @@ import java.util.UUID;
 public class PlayerSkinPacket extends BedrockPacket {
     private UUID uuid;
     private SerializedSkin skin;
-    private String oldSkinName;
     private String newSkinName;
+    private String oldSkinName;
     private boolean trustedSkin;
 
     @Override

--- a/bedrock/bedrock-v291/src/main/java/com/nukkitx/protocol/bedrock/v291/serializer/PlayerSkinSerializer_v291.java
+++ b/bedrock/bedrock-v291/src/main/java/com/nukkitx/protocol/bedrock/v291/serializer/PlayerSkinSerializer_v291.java
@@ -19,8 +19,8 @@ public class PlayerSkinSerializer_v291 implements PacketSerializer<PlayerSkinPac
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         SerializedSkin skin = packet.getSkin();
         BedrockUtils.writeString(buffer, skin.getSkinId());
-        BedrockUtils.writeString(buffer, "");
-        BedrockUtils.writeString(buffer, "");
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         skin.getSkinData().checkLegacySkinSize();
         BedrockUtils.writeByteArray(buffer, skin.getSkinData().getImage());
         skin.getCapeData().checkLegacyCapeSize();
@@ -34,8 +34,8 @@ public class PlayerSkinSerializer_v291 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         String skinId = BedrockUtils.readString(buffer);
-        BedrockUtils.readString(buffer); // new skin name
-        BedrockUtils.readString(buffer); // old skin name
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         ImageData skinData = ImageData.of(BedrockUtils.readByteArray(buffer));
         ImageData capeData = ImageData.of(64, 32, BedrockUtils.readByteArray(buffer));
         String geometryName = BedrockUtils.readString(buffer);

--- a/bedrock/bedrock-v313/src/main/java/com/nukkitx/protocol/bedrock/v313/serializer/PlayerSkinSerializer_v313.java
+++ b/bedrock/bedrock-v313/src/main/java/com/nukkitx/protocol/bedrock/v313/serializer/PlayerSkinSerializer_v313.java
@@ -19,8 +19,8 @@ public class PlayerSkinSerializer_v313 implements PacketSerializer<PlayerSkinPac
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         SerializedSkin skin = packet.getSkin();
         BedrockUtils.writeString(buffer, skin.getSkinId());
-        BedrockUtils.writeString(buffer, "");
-        BedrockUtils.writeString(buffer, "");
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         skin.getSkinData().checkLegacySkinSize();
         BedrockUtils.writeByteArray(buffer, skin.getSkinData().getImage());
         skin.getCapeData().checkLegacyCapeSize();
@@ -34,8 +34,8 @@ public class PlayerSkinSerializer_v313 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         String skinId = BedrockUtils.readString(buffer);
-        BedrockUtils.readString(buffer); // new skin name
-        BedrockUtils.readString(buffer); // old skin name
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         ImageData skinData = ImageData.of(BedrockUtils.readByteArray(buffer));
         ImageData capeData = ImageData.of(64, 32, BedrockUtils.readByteArray(buffer));
         String geometryName = BedrockUtils.readString(buffer);

--- a/bedrock/bedrock-v332/src/main/java/com/nukkitx/protocol/bedrock/v332/serializer/PlayerSkinSerializer_v332.java
+++ b/bedrock/bedrock-v332/src/main/java/com/nukkitx/protocol/bedrock/v332/serializer/PlayerSkinSerializer_v332.java
@@ -19,8 +19,8 @@ public class PlayerSkinSerializer_v332 implements PacketSerializer<PlayerSkinPac
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         SerializedSkin skin = packet.getSkin();
         BedrockUtils.writeString(buffer, skin.getSkinId());
-        BedrockUtils.writeString(buffer, "");
-        BedrockUtils.writeString(buffer, "");
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         skin.getSkinData().checkLegacySkinSize();
         BedrockUtils.writeByteArray(buffer, skin.getSkinData().getImage());
         skin.getCapeData().checkLegacyCapeSize();
@@ -34,8 +34,8 @@ public class PlayerSkinSerializer_v332 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         String skinId = BedrockUtils.readString(buffer);
-        BedrockUtils.readString(buffer); // new skin name
-        BedrockUtils.readString(buffer); // old skin name
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         ImageData skinData = ImageData.of(BedrockUtils.readByteArray(buffer));
         ImageData capeData = ImageData.of(64, 32, BedrockUtils.readByteArray(buffer));
         String geometryName = BedrockUtils.readString(buffer);

--- a/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/serializer/PlayerSkinSerializer_v340.java
+++ b/bedrock/bedrock-v340/src/main/java/com/nukkitx/protocol/bedrock/v340/serializer/PlayerSkinSerializer_v340.java
@@ -19,8 +19,8 @@ public class PlayerSkinSerializer_v340 implements PacketSerializer<PlayerSkinPac
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         SerializedSkin skin = packet.getSkin();
         BedrockUtils.writeString(buffer, skin.getSkinId());
-        BedrockUtils.writeString(buffer, "");
-        BedrockUtils.writeString(buffer, "");
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         skin.getSkinData().checkLegacySkinSize();
         BedrockUtils.writeByteArray(buffer, skin.getSkinData().getImage());
         skin.getCapeData().checkLegacyCapeSize();
@@ -34,8 +34,8 @@ public class PlayerSkinSerializer_v340 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         String skinId = BedrockUtils.readString(buffer);
-        BedrockUtils.readString(buffer); // new skin name
-        BedrockUtils.readString(buffer); // old skin name
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         ImageData skinData = ImageData.of(BedrockUtils.readByteArray(buffer));
         ImageData capeData = ImageData.of(64, 32, BedrockUtils.readByteArray(buffer));
         String geometryName = BedrockUtils.readString(buffer);

--- a/bedrock/bedrock-v354/src/main/java/com/nukkitx/protocol/bedrock/v354/serializer/PlayerSkinSerializer_v354.java
+++ b/bedrock/bedrock-v354/src/main/java/com/nukkitx/protocol/bedrock/v354/serializer/PlayerSkinSerializer_v354.java
@@ -19,8 +19,8 @@ public class PlayerSkinSerializer_v354 implements PacketSerializer<PlayerSkinPac
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         SerializedSkin skin = packet.getSkin();
         BedrockUtils.writeString(buffer, skin.getSkinId());
-        BedrockUtils.writeString(buffer, "");
-        BedrockUtils.writeString(buffer, "");
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         skin.getSkinData().checkLegacySkinSize();
         BedrockUtils.writeByteArray(buffer, skin.getSkinData().getImage());
         skin.getCapeData().checkLegacyCapeSize();
@@ -34,8 +34,8 @@ public class PlayerSkinSerializer_v354 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         String skinId = BedrockUtils.readString(buffer);
-        BedrockUtils.readString(buffer); // new skin name
-        BedrockUtils.readString(buffer); // old skin name
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         ImageData skinData = ImageData.of(BedrockUtils.readByteArray(buffer));
         ImageData capeData = ImageData.of(64, 32, BedrockUtils.readByteArray(buffer));
         String geometryName = BedrockUtils.readString(buffer);

--- a/bedrock/bedrock-v361/src/main/java/com/nukkitx/protocol/bedrock/v361/serializer/PlayerSkinSerializer_v361.java
+++ b/bedrock/bedrock-v361/src/main/java/com/nukkitx/protocol/bedrock/v361/serializer/PlayerSkinSerializer_v361.java
@@ -19,8 +19,8 @@ public class PlayerSkinSerializer_v361 implements PacketSerializer<PlayerSkinPac
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         SerializedSkin skin = packet.getSkin();
         BedrockUtils.writeString(buffer, skin.getSkinId());
-        BedrockUtils.writeString(buffer, "");
-        BedrockUtils.writeString(buffer, "");
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         skin.getSkinData().checkLegacySkinSize();
         BedrockUtils.writeByteArray(buffer, skin.getSkinData().getImage());
         skin.getCapeData().checkLegacyCapeSize();
@@ -34,8 +34,8 @@ public class PlayerSkinSerializer_v361 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         String skinId = BedrockUtils.readString(buffer);
-        BedrockUtils.readString(buffer); // new skin name
-        BedrockUtils.readString(buffer); // old skin name
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         ImageData skinData = ImageData.of(BedrockUtils.readByteArray(buffer));
         ImageData capeData = ImageData.of(64, 32, BedrockUtils.readByteArray(buffer));
         String geometryName = BedrockUtils.readString(buffer);

--- a/bedrock/bedrock-v388/src/main/java/com/nukkitx/protocol/bedrock/v388/serializer/PlayerSkinSerializer_v388.java
+++ b/bedrock/bedrock-v388/src/main/java/com/nukkitx/protocol/bedrock/v388/serializer/PlayerSkinSerializer_v388.java
@@ -16,11 +16,15 @@ public class PlayerSkinSerializer_v388 implements PacketSerializer<PlayerSkinPac
     public void serialize(ByteBuf buffer, PlayerSkinPacket packet) {
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         BedrockUtils.writeSkin(buffer, packet.getSkin());
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
     }
 
     @Override
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         packet.setSkin(BedrockUtils.readSkin(buffer));
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
     }
 }

--- a/bedrock/bedrock-v390/src/main/java/com/nukkitx/protocol/bedrock/v390/serializer/PlayerSkinSerializer_v390.java
+++ b/bedrock/bedrock-v390/src/main/java/com/nukkitx/protocol/bedrock/v390/serializer/PlayerSkinSerializer_v390.java
@@ -17,6 +17,8 @@ public class PlayerSkinSerializer_v390 implements PacketSerializer<PlayerSkinPac
     public void serialize(ByteBuf buffer, PlayerSkinPacket packet) {
         BedrockUtils.writeUuid(buffer, packet.getUuid());
         BedrockUtils_v390.writeSkin(buffer, packet.getSkin());
+        BedrockUtils.writeString(buffer, packet.getNewSkinName());
+        BedrockUtils.writeString(buffer, packet.getOldSkinName());
         buffer.writeBoolean(packet.isTrustedSkin());
     }
 
@@ -24,6 +26,8 @@ public class PlayerSkinSerializer_v390 implements PacketSerializer<PlayerSkinPac
     public void deserialize(ByteBuf buffer, PlayerSkinPacket packet) {
         packet.setUuid(BedrockUtils.readUuid(buffer));
         packet.setSkin(BedrockUtils_v390.readSkin(buffer));
+        packet.setNewSkinName(BedrockUtils.readString(buffer));
+        packet.setOldSkinName(BedrockUtils.readString(buffer));
         packet.setTrustedSkin(buffer.readBoolean());
     }
 }


### PR DESCRIPTION
These fields are present in 1.13 and 1.14 too, so they must be there for all protocol versions