### PR TITLE
Use new InflateStream to inflate WrappedPacket in WrapperSerializer

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV7.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV7.java
@@ -1,21 +1,26 @@
 package com.nukkitx.protocol.bedrock.wrapper;
 
+import java.util.Collection;
+import java.util.zip.DataFormatException;
+
 import com.nukkitx.network.VarInts;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockPacketCodec;
 import com.nukkitx.protocol.bedrock.exception.PacketSerializeException;
+import com.nukkitx.protocol.util.InflateStream;
 import com.nukkitx.protocol.util.Zlib;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
-
-import java.util.Collection;
-import java.util.zip.DataFormatException;
 
 public class BedrockWrapperSerializerV7 extends BedrockWrapperSerializer {
     public static final BedrockWrapperSerializerV7 INSTANCE = new BedrockWrapperSerializerV7();
 
     private static final Zlib ZLIB = Zlib.DEFAULT;
+
+    private static final int BUFFER_SIZE = 2 * 1024 * 1024;
+    private static final int CHUNK_SIZE = 8192;
 
     @Override
     public void serialize(ByteBuf buffer, BedrockPacketCodec codec, Collection<BedrockPacket> packets, int level) {
@@ -46,30 +51,63 @@ public class BedrockWrapperSerializerV7 extends BedrockWrapperSerializer {
 
     @Override
     public void deserialize(ByteBuf compressed, BedrockPacketCodec codec, Collection<BedrockPacket> packets) {
-        ByteBuf decompressed = null;
+        ByteBuf decompressed = ByteBufAllocator.DEFAULT.ioBuffer(BUFFER_SIZE);
+
+        InflateStream stream = ZLIB.inflateStream(compressed);
         try {
-            decompressed = ZLIB.inflate(compressed, 2 * 1024 * 1024); // 2MBs
-
-            while (decompressed.isReadable()) {
-                int length = VarInts.readUnsignedInt(decompressed);
-                ByteBuf packetBuffer = decompressed.readSlice(length);
-
-                if (!packetBuffer.isReadable()) {
-                    throw new DataFormatException("Packet cannot be empty");
-                }
+            while (!stream.finished()) {
+                // Inflate initial chunk
+                int read = stream.inflateChunk(decompressed, CHUNK_SIZE);
+                log.trace("Read {} bytes. Current buffer: {}", read, decompressed);
 
                 try {
-                    int packetId = packetBuffer.readUnsignedByte();
-                    BedrockPacket packet = codec.tryDecode(packetBuffer, packetId);
-                    packets.add(packet);
-                } catch (PacketSerializeException e) {
-                    log.debug("Error occurred whilst decoding packet", e);
-                    log.trace("Packet contents\n{}", ByteBufUtil.prettyHexDump(packetBuffer.readerIndex(0)));
+                    // Store reader index for if we don't have enough bytes
+                    // to get the length of the next packet
+                    decompressed.markReaderIndex();
+                    int length = VarInts.readUnsignedInt(decompressed);
+
+                    // Inflate enough bytes for the next packet or at least CHUNK_SIZE bytes
+                    while (decompressed.readableBytes() < length) {
+                        read = stream.inflateChunk(decompressed, Math.max(CHUNK_SIZE, length - decompressed.readableBytes()));
+                        log.trace("Read {} bytes. Current buffer: {}. {} bytes needed for packet.", read, decompressed, length);
+                    }
+
+                    // We should have enough bytes, but just in case
+                    if (decompressed.readableBytes() >= length) {
+                        ByteBuf packetBuffer = decompressed.readSlice(length);
+
+                        if (!packetBuffer.isReadable()) {
+                            throw new DataFormatException("Packet cannot be empty");
+                        }
+
+                        try {
+                            int packetId = packetBuffer.readUnsignedByte();
+                            BedrockPacket packet = codec.tryDecode(packetBuffer, packetId);
+                            packets.add(packet);
+                        } catch (PacketSerializeException e) {
+                            log.debug("Error occurred whilst decoding packet", e);
+                            log.trace("Packet contents\n{}", ByteBufUtil.prettyHexDump(packetBuffer.readerIndex(0)));
+                        }
+                    } else {
+                        // We need to read the length bytes again in the next loop iteration
+                        decompressed.resetReaderIndex();
+                    }
+                } catch (ArithmeticException e) {
+                    log.debug("Failed to read length: {}", e.getMessage(), e);
+                    // We need to read the length bytes again in the next loop iteration
+                    decompressed.resetReaderIndex();
                 }
+
+                // Read bytes have been decoded into packets and can be discarded
+                // freeing up space in the buffer. We call this late to minimize overhead
+                decompressed.discardReadBytes();
             }
         } catch (DataFormatException e) {
             throw new RuntimeException("Unable to inflate buffer data", e);
         } finally {
+            // We need to free the stream to release the source buffer & free the inflater
+            stream.free();
+
             if (decompressed != null) {
                 decompressed.release();
             }

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV8.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV8.java
@@ -1,24 +1,29 @@
 package com.nukkitx.protocol.bedrock.wrapper;
 
+import java.util.Collection;
+import java.util.zip.DataFormatException;
+
 import com.nukkitx.network.VarInts;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockPacketCodec;
 import com.nukkitx.protocol.bedrock.exception.PacketSerializeException;
+import com.nukkitx.protocol.util.InflateStream;
 import com.nukkitx.protocol.util.Zlib;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.util.Collection;
-import java.util.zip.DataFormatException;
-
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class BedrockWrapperSerializerV8 extends BedrockWrapperSerializer {
     public static final BedrockWrapperSerializerV8 INSTANCE = new BedrockWrapperSerializerV8();
 
     private static final Zlib ZLIB = Zlib.DEFAULT;
+
+    private static final int BUFFER_SIZE = 2 * 1024 * 1024;
+    private static final int CHUNK_SIZE = 8192;
 
     @Override
     public void serialize(ByteBuf buffer, BedrockPacketCodec codec, Collection<BedrockPacket> packets, int level) {
@@ -51,32 +56,65 @@ public class BedrockWrapperSerializerV8 extends BedrockWrapperSerializer {
 
     @Override
     public void deserialize(ByteBuf compressed, BedrockPacketCodec codec, Collection<BedrockPacket> packets) {
-        ByteBuf decompressed = null;
+        ByteBuf decompressed = ByteBufAllocator.DEFAULT.ioBuffer(BUFFER_SIZE);
+
+        InflateStream stream = ZLIB.inflateStream(compressed);
         try {
-            decompressed = ZLIB.inflate(compressed, 2 * 1024 * 1024); // 2MBs
-
-            while (decompressed.isReadable()) {
-                int length = VarInts.readUnsignedInt(decompressed);
-                ByteBuf packetBuffer = decompressed.readSlice(length);
-
-                if (!packetBuffer.isReadable()) {
-                    throw new DataFormatException("Packet cannot be empty");
-                }
+            while (!stream.finished()) {
+                // Inflate initial chunk
+                int read = stream.inflateChunk(decompressed, CHUNK_SIZE);
+                log.trace("Read {} bytes. Current buffer: {}", read, decompressed);
 
                 try {
-                    int packetId = packetBuffer.readUnsignedByte();
-                    BedrockPacket packet = codec.tryDecode(packetBuffer, packetId);
-                    packet.setSenderId(packetBuffer.readUnsignedByte());
-                    packet.setClientId(packetBuffer.readUnsignedByte());
-                    packets.add(packet);
-                } catch (PacketSerializeException e) {
-                    log.debug("Error occurred whilst decoding packet", e);
-                    log.trace("Packet contents\n{}", ByteBufUtil.prettyHexDump(packetBuffer.readerIndex(0)));
+                    // Store reader index for if we don't have enough bytes
+                    // to get the length of the next packet
+                    decompressed.markReaderIndex();
+                    int length = VarInts.readUnsignedInt(decompressed);
+
+                    // Inflate enough bytes for the next packet or at least CHUNK_SIZE bytes
+                    while (decompressed.readableBytes() < length) {
+                        read = stream.inflateChunk(decompressed, Math.max(CHUNK_SIZE, length - decompressed.readableBytes()));
+                        log.trace("Read {} bytes. Current buffer: {}. {} bytes needed for packet.", read, decompressed, length);
+                    }
+
+                    // We should have enough bytes, but just in case
+                    if (decompressed.readableBytes() >= length) {
+                        ByteBuf packetBuffer = decompressed.readSlice(length);
+
+                        if (!packetBuffer.isReadable()) {
+                            throw new DataFormatException("Packet cannot be empty");
+                        }
+
+                        try {
+                            int packetId = packetBuffer.readUnsignedByte();
+                            BedrockPacket packet = codec.tryDecode(packetBuffer, packetId);
+                            packet.setSenderId(packetBuffer.readUnsignedByte());
+                            packet.setClientId(packetBuffer.readUnsignedByte());
+                            packets.add(packet);
+                        } catch (PacketSerializeException e) {
+                            log.debug("Error occurred whilst decoding packet", e);
+                            log.trace("Packet contents\n{}", ByteBufUtil.prettyHexDump(packetBuffer.readerIndex(0)));
+                        }
+                    } else {
+                        // We need to read the length bytes again in the next loop iteration
+                        decompressed.resetReaderIndex();
+                    }
+                } catch (ArithmeticException e) {
+                    log.debug("Failed to read length: {}", e.getMessage(), e);
+                    // We need to read the length bytes again in the next loop iteration
+                    decompressed.resetReaderIndex();
                 }
+
+                // Read bytes have been decoded into packets and can be discarded
+                // freeing up space in the buffer. We call this late to minimize overhead
+                decompressed.discardReadBytes();
             }
         } catch (DataFormatException e) {
             throw new RuntimeException("Unable to inflate buffer data", e);
         } finally {
+            // We need to free the stream to release the source buffer & free the inflater
+            stream.free();
+
             if (decompressed != null) {
                 decompressed.release();
             }

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV9_10.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV9_10.java
@@ -1,22 +1,27 @@
 package com.nukkitx.protocol.bedrock.wrapper;
 
+import java.util.Collection;
+import java.util.zip.DataFormatException;
+
 import com.nukkitx.network.VarInts;
 import com.nukkitx.protocol.bedrock.BedrockPacket;
 import com.nukkitx.protocol.bedrock.BedrockPacketCodec;
 import com.nukkitx.protocol.bedrock.exception.PacketSerializeException;
+import com.nukkitx.protocol.util.InflateStream;
 import com.nukkitx.protocol.util.Zlib;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.ByteBufUtil;
-
-import java.util.Collection;
-import java.util.zip.DataFormatException;
 
 public class BedrockWrapperSerializerV9_10 extends BedrockWrapperSerializer {
     public static final BedrockWrapperSerializerV9_10 V9 = new BedrockWrapperSerializerV9_10(Zlib.DEFAULT);
     public static final BedrockWrapperSerializerV9_10 V10 = new BedrockWrapperSerializerV9_10(Zlib.RAW);
 
     private final Zlib zlib;
+
+    private static final int BUFFER_SIZE = 2 * 1024 * 1024;
+    private static final int CHUNK_SIZE = 8192;
 
     private BedrockWrapperSerializerV9_10(Zlib zlib) {
         this.zlib = zlib;
@@ -55,33 +60,66 @@ public class BedrockWrapperSerializerV9_10 extends BedrockWrapperSerializer {
 
     @Override
     public void deserialize(ByteBuf compressed, BedrockPacketCodec codec, Collection<BedrockPacket> packets) {
-        ByteBuf decompressed = null;
+        ByteBuf decompressed = ByteBufAllocator.DEFAULT.ioBuffer(BUFFER_SIZE);
+
+        InflateStream stream = zlib.inflateStream(compressed);
         try {
-            decompressed = zlib.inflate(compressed, 2 * 1024 * 1024); // 2MBs
-
-            while (decompressed.isReadable()) {
-                int length = VarInts.readUnsignedInt(decompressed);
-                ByteBuf packetBuffer = decompressed.readSlice(length);
-
-                if (!packetBuffer.isReadable()) {
-                    throw new DataFormatException("Packet cannot be empty");
-                }
+            while (!stream.finished()) {
+                // Inflate initial chunk
+                int read = stream.inflateChunk(decompressed, CHUNK_SIZE);
+                log.trace("Read {} bytes. Current buffer: {}", read, decompressed);
 
                 try {
-                    int header = VarInts.readUnsignedInt(packetBuffer);
-                    int packetId = header & 0x3ff;
-                    BedrockPacket packet = codec.tryDecode(packetBuffer, packetId);
-                    packet.setSenderId((header >>> 10) & 3);
-                    packet.setClientId((header >>> 12) & 3);
-                    packets.add(packet);
-                } catch (PacketSerializeException e) {
-                    log.debug("Error occurred whilst decoding packet", e);
-                    log.trace("Packet contents\n{}", ByteBufUtil.prettyHexDump(packetBuffer.readerIndex(0)));
+                    // Store reader index for if we don't have enough bytes
+                    // to get the length of the next packet
+                    decompressed.markReaderIndex();
+                    int length = VarInts.readUnsignedInt(decompressed);
+
+                    // Inflate enough bytes for the next packet or at least CHUNK_SIZE bytes
+                    while (decompressed.readableBytes() < length) {
+                        read = stream.inflateChunk(decompressed, Math.max(CHUNK_SIZE, length - decompressed.readableBytes()));
+                        log.trace("Read {} bytes. Current buffer: {}. {} bytes needed for packet.", read, decompressed, length);
+                    }
+
+                    // We should have enough bytes, but just in case
+                    if (decompressed.readableBytes() >= length) {
+                        ByteBuf packetBuffer = decompressed.readSlice(length);
+
+                        if (!packetBuffer.isReadable()) {
+                            throw new DataFormatException("Packet cannot be empty");
+                        }
+
+                        try {
+                            int header = VarInts.readUnsignedInt(packetBuffer);
+                            int packetId = header & 0x3ff;
+                            BedrockPacket packet = codec.tryDecode(packetBuffer, packetId);
+                            packet.setSenderId((header >>> 10) & 3);
+                            packet.setClientId((header >>> 12) & 3);
+                            packets.add(packet);
+                        } catch (PacketSerializeException e) {
+                            log.debug("Error occurred whilst decoding packet", e);
+                            log.trace("Packet contents\n{}", ByteBufUtil.prettyHexDump(packetBuffer.readerIndex(0)));
+                        }
+                    } else {
+                        // We need to read the length bytes again in the next loop iteration
+                        decompressed.resetReaderIndex();
+                    }
+                } catch (ArithmeticException e) {
+                    log.debug("Failed to read length: {}", e.getMessage(), e);
+                    // We need to read the length bytes again in the next loop iteration
+                    decompressed.resetReaderIndex();
                 }
+
+                // Read bytes have been decoded into packets and can be discarded
+                // freeing up space in the buffer. We call this late to minimize overhead
+                decompressed.discardReadBytes();
             }
         } catch (DataFormatException e) {
             throw new RuntimeException("Unable to inflate buffer data", e);
         } finally {
+            // We need to free the stream to release the source buffer & free the inflater
+            stream.free();
+
             if (decompressed != null) {
                 decompressed.release();
             }

--- a/common/src/main/java/com/nukkitx/protocol/util/InflateStream.java
+++ b/common/src/main/java/com/nukkitx/protocol/util/InflateStream.java
@@ -45,8 +45,6 @@ public class InflateStream {
     }
 
     public void free() {
-        inflater.free();
-
         if (source.readableBytes() > 0) {
             log.error("Source not empty! {}", source);
             if (log.isTraceEnabled()) {

--- a/common/src/main/java/com/nukkitx/protocol/util/InflateStream.java
+++ b/common/src/main/java/com/nukkitx/protocol/util/InflateStream.java
@@ -1,0 +1,62 @@
+package com.nukkitx.protocol.util;
+
+import java.util.zip.DataFormatException;
+
+import com.nukkitx.natives.zlib.Inflater;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class InflateStream {
+    protected static final InternalLogger log = InternalLoggerFactory.getInstance(InflateStream.class);
+
+    Inflater inflater;
+    ByteBuf source;
+    boolean doRelease;
+
+    public InflateStream(Inflater inflater, ByteBuf source, boolean doRelease) {
+        this.inflater = inflater;
+        this.source = source;
+        this.doRelease = doRelease;
+    }
+
+    public boolean finished() {
+        return inflater.finished();
+    }
+
+    public int inflateChunk(ByteBuf decompressed, int chunk) throws DataFormatException {
+        try {
+            decompressed.ensureWritable(chunk);
+            int index = decompressed.writerIndex();
+            int written = inflater.inflate(decompressed.internalNioBuffer(index, chunk));
+            decompressed.writerIndex(index + written);
+
+            source.readerIndex((int)inflater.getBytesRead());
+
+            return written;
+        } catch (DataFormatException e) {
+            decompressed.release();
+            throw e;
+        }
+    }
+
+    public void free() {
+        inflater.free();
+
+        if (source.readableBytes() > 0) {
+            log.error("Source not empty! {}", source);
+            if (log.isTraceEnabled()) {
+                ByteBuf hexdump = source.readBytes(source.readableBytes());
+                log.trace(ByteBufUtil.prettyHexDump(hexdump));
+                hexdump.release();
+            }
+        }
+        if (doRelease) {
+            source.release();
+        }
+    }
+}

--- a/common/src/main/java/com/nukkitx/protocol/util/InflateStream.java
+++ b/common/src/main/java/com/nukkitx/protocol/util/InflateStream.java
@@ -46,8 +46,8 @@ public class InflateStream {
 
     public void free() {
         if (source.readableBytes() > 0) {
-            log.error("Source not empty! {}", source);
             if (log.isTraceEnabled()) {
+                log.trace("Source not empty! {}", source);
                 ByteBuf hexdump = source.readBytes(source.readableBytes());
                 log.trace(ByteBufUtil.prettyHexDump(hexdump));
                 hexdump.release();


### PR DESCRIPTION
I did an initial implementation that uses a stream rather than inflating the whole compressed buffer at once. This limits memory usage to some extent, although the compressed buffer can still be rather large. Changing that doesn't seem feasible at this point.

This also solves the problem of Nintendo Switch split-screen sending WrappedPackets / Batches that are larger than the 2MB limit.

Buffer is currently 2MB, but since it only has to hold between CHUNK_SIZE and the size of the next packet from the WrappedPacket, this should be plenty. Could be decreased if we have a good idea of the maximum packet size we can expect.

Uses InflateStream from CloudburstMC/Natives#1.

InflateStream is close to java.util.zip.InflaterStream, which could be used, but can't deal with current Natives.