### PR TITLE
Increases inflate limit for SubClient (splitscreen) support

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV9_10.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/wrapper/BedrockWrapperSerializerV9_10.java
@@ -57,7 +57,7 @@ public class BedrockWrapperSerializerV9_10 extends BedrockWrapperSerializer {
     public void deserialize(ByteBuf compressed, BedrockPacketCodec codec, Collection<BedrockPacket> packets) {
         ByteBuf decompressed = null;
         try {
-            decompressed = zlib.inflate(compressed, 2 * 1024 * 1024); // 2MBs
+            decompressed = zlib.inflate(compressed, 12 * 1024 * 1024); // 12MBs
 
             while (decompressed.isReadable()) {
                 int length = VarInts.readUnsignedInt(decompressed);


### PR DESCRIPTION
Temporary fix for SubClient support. I've seen Nintendo Switch send WrappedPackets up to 40-50 Packets and 4,5MB (maybe even 10+MB). This is probably mostly due to SkinData and GeomeotryData.

This is a required change to support SubClients in Geyser.

Alternative solution (that handles this more efficiently in general by not inflating the whole WrappedPacket at once) in #62.