### PR TITLE
Implement missing MINE_BLOCK inventory action handler

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/inventory/stackrequestactions/MineBlockStackRequestActionData.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/inventory/stackrequestactions/MineBlockStackRequestActionData.java
@@ -1,0 +1,19 @@
+package com.nukkitx.protocol.bedrock.data.inventory.stackrequestactions;
+
+import lombok.Value;
+
+/**
+ * MineBlockStackRequestActionData is sent by the client when it breaks a block.
+ */
+@Value
+public class MineBlockStackRequestActionData implements StackRequestActionData {
+    int hotbarSlot;
+    int predictedDurability;
+    int stackNetworkId;
+
+    @Override
+    public StackRequestActionType getType() {
+        return StackRequestActionType.MINE_BLOCK;
+    }
+
+}

--- a/bedrock/bedrock-v428/src/main/java/com/nukkitx/protocol/bedrock/v428/BedrockPacketHelper_v428.java
+++ b/bedrock/bedrock-v428/src/main/java/com/nukkitx/protocol/bedrock/v428/BedrockPacketHelper_v428.java
@@ -1,10 +1,15 @@
 package com.nukkitx.protocol.bedrock.v428;
 
+import com.nukkitx.network.VarInts;
+import com.nukkitx.protocol.bedrock.BedrockSession;
 import com.nukkitx.protocol.bedrock.data.LevelEventType;
 import com.nukkitx.protocol.bedrock.data.SoundEvent;
 import com.nukkitx.protocol.bedrock.data.command.CommandParam;
 import com.nukkitx.protocol.bedrock.data.entity.EntityData;
 import com.nukkitx.protocol.bedrock.data.entity.EntityFlag;
+import com.nukkitx.protocol.bedrock.data.inventory.stackrequestactions.MineBlockStackRequestActionData;
+import com.nukkitx.protocol.bedrock.data.inventory.stackrequestactions.StackRequestActionData;
+import com.nukkitx.protocol.bedrock.data.inventory.stackrequestactions.StackRequestActionType;
 import com.nukkitx.protocol.bedrock.data.skin.*;
 import com.nukkitx.protocol.bedrock.v422.BedrockPacketHelper_v422;
 import io.netty.buffer.ByteBuf;
@@ -164,6 +169,28 @@ public class BedrockPacketHelper_v428 extends BedrockPacketHelper_v422 {
         this.stackRequestActionTypes.put(13, CRAFT_RECIPE_OPTIONAL);
         this.stackRequestActionTypes.put(14, CRAFT_NON_IMPLEMENTED_DEPRECATED);
         this.stackRequestActionTypes.put(15, CRAFT_RESULTS_DEPRECATED);
+    }
+
+    @Override
+    protected StackRequestActionData readRequestActionData(ByteBuf byteBuf, StackRequestActionType type, BedrockSession session) {
+        StackRequestActionData action;
+        if (type == StackRequestActionType.MINE_BLOCK) {
+            action = new MineBlockStackRequestActionData(VarInts.readInt(byteBuf), VarInts.readInt(byteBuf), VarInts.readInt(byteBuf));
+        } else {
+            action = super.readRequestActionData(byteBuf, type, session);
+        }
+        return action;
+    }
+
+    @Override
+    protected void writeRequestActionData(ByteBuf byteBuf, StackRequestActionData action, BedrockSession session) {
+        if (action.getType() == StackRequestActionType.MINE_BLOCK) {
+            VarInts.writeInt(byteBuf, ((MineBlockStackRequestActionData) action).getHotbarSlot());
+            VarInts.writeInt(byteBuf, ((MineBlockStackRequestActionData) action).getPredictedDurability());
+            VarInts.writeInt(byteBuf, ((MineBlockStackRequestActionData) action).getStackNetworkId());
+        } else {
+            super.writeRequestActionData(byteBuf, action, session);
+        }
     }
 
     @SuppressWarnings("DuplicatedCode")


### PR DESCRIPTION
Currently, stack request actions with MINE_BLOCK are not deserialized/serialized causing exceptions when they are retrieved. This pull request seeks to fix that by implementing the serializer/deserializer for it.