### PR TITLE
Add some missing command params from 1.19

### DIFF
--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/command/CommandParam.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/command/CommandParam.java
@@ -13,6 +13,7 @@ public class CommandParam {
     public static final CommandParam VALUE = new CommandParam(CommandParamType.VALUE);
     public static final CommandParam WILDCARD_INT = new CommandParam(CommandParamType.WILDCARD_INT);
     public static final CommandParam OPERATOR = new CommandParam(CommandParamType.OPERATOR);
+    public static final CommandParam COMPARE_OPERATOR = new CommandParam(CommandParamType.COMPARE_OPERATOR);
     public static final CommandParam TARGET = new CommandParam(CommandParamType.TARGET);
     public static final CommandParam WILDCARD_TARGET = new CommandParam(CommandParamType.WILDCARD_TARGET);
     public static final CommandParam FILE_PATH = new CommandParam(CommandParamType.FILE_PATH);
@@ -23,6 +24,7 @@ public class CommandParam {
     public static final CommandParam MESSAGE = new CommandParam(CommandParamType.MESSAGE);
     public static final CommandParam TEXT = new CommandParam(CommandParamType.TEXT);
     public static final CommandParam JSON = new CommandParam(CommandParamType.JSON);
+    public static final CommandParam BLOCK_STATES = new CommandParam(CommandParamType.BLOCK_STATES);
     public static final CommandParam COMMAND = new CommandParam(CommandParamType.COMMAND);
 
     private final CommandParamType paramType;

--- a/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/command/CommandParamType.java
+++ b/bedrock/bedrock-common/src/main/java/com/nukkitx/protocol/bedrock/data/command/CommandParamType.java
@@ -6,6 +6,7 @@ public enum CommandParamType {
     VALUE,
     WILDCARD_INT,
     OPERATOR,
+    COMPARE_OPERATOR,
     TARGET,
     WILDCARD_TARGET,
     FILE_PATH,
@@ -16,5 +17,6 @@ public enum CommandParamType {
     MESSAGE,
     TEXT,
     JSON,
+    BLOCK_STATES,
     COMMAND
 }

--- a/bedrock/bedrock-v527/src/main/java/com/nukkitx/protocol/bedrock/v527/BedrockPacketHelper_v527.java
+++ b/bedrock/bedrock-v527/src/main/java/com/nukkitx/protocol/bedrock/v527/BedrockPacketHelper_v527.java
@@ -17,6 +17,7 @@ public class BedrockPacketHelper_v527 extends BedrockPacketHelper_v503 {
         this.addCommandParam(4, CommandParam.VALUE);
         this.addCommandParam(5, CommandParam.WILDCARD_INT);
         this.addCommandParam(6, CommandParam.OPERATOR);
+        this.addCommandParam(7, CommandParam.COMPARE_OPERATOR);
         this.addCommandParam(8, CommandParam.TARGET);
         this.addCommandParam(10, CommandParam.WILDCARD_TARGET);
 
@@ -28,6 +29,7 @@ public class BedrockPacketHelper_v527 extends BedrockPacketHelper_v503 {
         this.addCommandParam(51, CommandParam.MESSAGE);
         this.addCommandParam(53, CommandParam.TEXT);
         this.addCommandParam(57, CommandParam.JSON);
+        this.addCommandParam(67, CommandParam.BLOCK_STATES);
         this.addCommandParam(70, CommandParam.COMMAND);
     }
 


### PR DESCRIPTION
Based off of https://github.com/pmmp/BedrockProtocol/blob/master/src/AvailableCommandsPacket.php