### PR TITLE
[3.0] Fix force experimental gameplay

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v407/serializer/StartGameSerializer_v407.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v407/serializer/StartGameSerializer_v407.java
@@ -10,7 +10,6 @@ import org.cloudburstmc.protocol.bedrock.data.GameType;
 import org.cloudburstmc.protocol.bedrock.data.PlayerPermission;
 import org.cloudburstmc.protocol.bedrock.data.SpawnBiomeType;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
-import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -74,8 +73,7 @@ public class StartGameSerializer_v407 extends StartGameSerializer_v388 {
         buffer.writeIntLE(packet.getLimitedWorldWidth());
         buffer.writeIntLE(packet.getLimitedWorldHeight());
         buffer.writeBoolean(packet.isNetherType());
-        helper.writeOptional(buffer, OptionalBoolean::isPresent, packet.getForceExperimentalGameplay(),
-                (buf, optional) -> buf.writeBoolean(optional.getAsBoolean()));
+        buffer.writeBoolean(packet.isForceExperimentalGameplay());
     }
 
     @Override
@@ -118,6 +116,6 @@ public class StartGameSerializer_v407 extends StartGameSerializer_v388 {
         packet.setLimitedWorldWidth(buffer.readIntLE());
         packet.setLimitedWorldHeight(buffer.readIntLE());
         packet.setNetherType(buffer.readBoolean());
-        packet.setForceExperimentalGameplay(helper.readOptional(buffer, OptionalBoolean.empty(), buf -> OptionalBoolean.of(buf.readBoolean())));
+        packet.setForceExperimentalGameplay(buffer.readBoolean());
     }
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/serializer/StartGameSerializer_v419.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/serializer/StartGameSerializer_v419.java
@@ -9,7 +9,6 @@ import org.cloudburstmc.protocol.bedrock.codec.BedrockPacketSerializer;
 import org.cloudburstmc.protocol.bedrock.data.*;
 import org.cloudburstmc.protocol.bedrock.data.defintions.SimpleItemDefinition;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
-import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 @SuppressWarnings("DuplicatedCode")
@@ -130,8 +129,7 @@ public class StartGameSerializer_v419 implements BedrockPacketSerializer<StartGa
         buffer.writeIntLE(packet.getLimitedWorldWidth());
         buffer.writeIntLE(packet.getLimitedWorldHeight());
         buffer.writeBoolean(packet.isNetherType());
-        helper.writeOptional(buffer, OptionalBoolean::isPresent, packet.getForceExperimentalGameplay(),
-                (buf, optional) -> buf.writeBoolean(optional.getAsBoolean()));
+        buffer.writeBoolean(packet.isForceExperimentalGameplay());
     }
 
     protected void readLevelSettings(ByteBuf buffer, BedrockCodecHelper helper, StartGamePacket packet) {
@@ -175,7 +173,7 @@ public class StartGameSerializer_v419 implements BedrockPacketSerializer<StartGa
         packet.setLimitedWorldWidth(buffer.readIntLE());
         packet.setLimitedWorldHeight(buffer.readIntLE());
         packet.setNetherType(buffer.readBoolean());
-        packet.setForceExperimentalGameplay(helper.readOptional(buffer, OptionalBoolean.empty(), buf -> OptionalBoolean.of(buf.readBoolean())));
+        packet.setForceExperimentalGameplay(buffer.readBoolean());
     }
 
     protected long readSeed(ByteBuf buffer) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v465/serializer/StartGameSerializer_v465.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v465/serializer/StartGameSerializer_v465.java
@@ -10,7 +10,6 @@ import org.cloudburstmc.protocol.bedrock.data.GamePublishSetting;
 import org.cloudburstmc.protocol.bedrock.data.GameType;
 import org.cloudburstmc.protocol.bedrock.data.SpawnBiomeType;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
-import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -61,8 +60,7 @@ public class StartGameSerializer_v465 extends StartGameSerializer_v440 {
         buffer.writeBoolean(packet.isNetherType());
         helper.writeString(buffer, packet.getEduSharedUriResource().getButtonName());
         helper.writeString(buffer, packet.getEduSharedUriResource().getLinkUri());
-        helper.writeOptional(buffer, OptionalBoolean::isPresent, packet.getForceExperimentalGameplay(),
-                (buf, optional) -> buf.writeBoolean(optional.getAsBoolean()));
+        buffer.writeBoolean(packet.isForceExperimentalGameplay());
     }
 
     @Override
@@ -108,6 +106,6 @@ public class StartGameSerializer_v465 extends StartGameSerializer_v440 {
         packet.setLimitedWorldHeight(buffer.readIntLE());
         packet.setNetherType(buffer.readBoolean());
         packet.setEduSharedUriResource(new EduSharedUriResource(helper.readString(buffer), helper.readString(buffer)));
-        packet.setForceExperimentalGameplay(helper.readOptional(buffer, OptionalBoolean.empty(), buf -> OptionalBoolean.of(buf.readBoolean())));
+        packet.setForceExperimentalGameplay(buffer.readBoolean());
     }
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v534/serializer/StartGameSerializer_v534.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v534/serializer/StartGameSerializer_v534.java
@@ -10,7 +10,6 @@ import org.cloudburstmc.protocol.bedrock.data.GamePublishSetting;
 import org.cloudburstmc.protocol.bedrock.data.GameType;
 import org.cloudburstmc.protocol.bedrock.data.SpawnBiomeType;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
-import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -62,8 +61,7 @@ public class StartGameSerializer_v534 extends StartGameSerializer_v527 {
         buffer.writeBoolean(packet.isNetherType());
         helper.writeString(buffer, packet.getEduSharedUriResource().getButtonName());
         helper.writeString(buffer, packet.getEduSharedUriResource().getLinkUri());
-        helper.writeOptional(buffer, OptionalBoolean::isPresent, packet.getForceExperimentalGameplay(),
-                (buf, optional) -> buf.writeBoolean(optional.getAsBoolean()));
+        buffer.writeBoolean(packet.isForceExperimentalGameplay());
     }
 
     @Override
@@ -110,6 +108,6 @@ public class StartGameSerializer_v534 extends StartGameSerializer_v527 {
         packet.setLimitedWorldHeight(buffer.readIntLE());
         packet.setNetherType(buffer.readBoolean());
         packet.setEduSharedUriResource(new EduSharedUriResource(helper.readString(buffer), helper.readString(buffer)));
-        packet.setForceExperimentalGameplay(helper.readOptional(buffer, OptionalBoolean.empty(), buf -> OptionalBoolean.of(buf.readBoolean())));
+        packet.setForceExperimentalGameplay(buffer.readBoolean());
     }
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v544/serializer/StartGameSerializer_v544.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v544/serializer/StartGameSerializer_v544.java
@@ -5,7 +5,6 @@ import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.codec.v534.serializer.StartGameSerializer_v534;
 import org.cloudburstmc.protocol.bedrock.data.*;
 import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
-import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 public class StartGameSerializer_v544 extends StartGameSerializer_v534 {
@@ -70,8 +69,7 @@ public class StartGameSerializer_v544 extends StartGameSerializer_v534 {
         buffer.writeBoolean(packet.isNetherType());
         helper.writeString(buffer, packet.getEduSharedUriResource().getButtonName());
         helper.writeString(buffer, packet.getEduSharedUriResource().getLinkUri());
-        helper.writeOptional(buffer, OptionalBoolean::isPresent, packet.getForceExperimentalGameplay(),
-                (buf, optional) -> buf.writeBoolean(optional.getAsBoolean()));
+        buffer.writeBoolean(packet.isForceExperimentalGameplay());
         buffer.writeByte(packet.getChatRestrictionLevel().ordinal()); // Added
         buffer.writeBoolean(packet.isDisablingPlayerInteractions()); // Added
     }
@@ -122,7 +120,7 @@ public class StartGameSerializer_v544 extends StartGameSerializer_v534 {
         packet.setLimitedWorldHeight(buffer.readIntLE());
         packet.setNetherType(buffer.readBoolean());
         packet.setEduSharedUriResource(new EduSharedUriResource(helper.readString(buffer), helper.readString(buffer)));
-        packet.setForceExperimentalGameplay(helper.readOptional(buffer, OptionalBoolean.empty(), buf -> OptionalBoolean.of(buf.readBoolean())));
+        packet.setForceExperimentalGameplay(buffer.readBoolean());
         packet.setChatRestrictionLevel(ChatRestrictionLevel.values()[buffer.readByte()]); // Added
         packet.setDisablingPlayerInteractions(buffer.readBoolean()); // Added
     }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/StartGamePacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/StartGamePacket.java
@@ -14,7 +14,6 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.protocol.bedrock.data.*;
 import org.cloudburstmc.protocol.bedrock.data.defintions.ItemDefinition;
 import org.cloudburstmc.protocol.common.PacketSignal;
-import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 
 import java.util.List;
 import java.util.UUID;
@@ -76,7 +75,7 @@ public class StartGamePacket implements BedrockPacket {
      * @since v465
      */
     private EduSharedUriResource eduSharedUriResource = EduSharedUriResource.EMPTY;
-    private OptionalBoolean forceExperimentalGameplay;
+    private boolean forceExperimentalGameplay;
     /**
      * @since 1.19.20
      */


### PR DESCRIPTION
StartGamePacket#forceExperimentalGameplay is not an optional boolean, so if you send another boolean after the first one that already said that force experimental gameplay was enabled, the bytes afterwards are corrupted and this is resulting in the client closing the connection.

Tested with: https://github.com/CloudburstMC/Server/tree/refactor/items
```java
startGamePacket.setForceExperimentalGameplay(OptionalBoolean.of(true));
```
Changed to:
```java
startGamePacket.setForceExperimentalGameplay(true);
```