### PR TITLE
fix: some servers sent -1 for default player permission

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/StartGameSerializer_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/StartGameSerializer_v291.java
@@ -105,7 +105,7 @@ public class StartGameSerializer_v291 implements BedrockPacketSerializer<StartGa
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
         buffer.writeBoolean(packet.isTrustingPlayers());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         VarInts.writeInt(buffer, packet.getXblBroadcastMode().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.getPlatformBroadcastMode() != GamePublishSetting.NO_MULTI_PLAY);
@@ -139,7 +139,8 @@ public class StartGameSerializer_v291 implements BedrockPacketSerializer<StartGa
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
         packet.setTrustingPlayers(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setXblBroadcastMode(GamePublishSetting.byId(VarInts.readInt(buffer)));
         packet.setServerChunkTickRange(buffer.readIntLE());
         buffer.readBoolean(); // Broadcasting to Platform

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v332/serializer/StartGameSerializer_v332.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v332/serializer/StartGameSerializer_v332.java
@@ -38,7 +38,7 @@ public class StartGameSerializer_v332 extends StartGameSerializer_v291 { // No n
         helper.writeArray(buffer, packet.getGamerules(), helper::writeGameRule);
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -72,7 +72,8 @@ public class StartGameSerializer_v332 extends StartGameSerializer_v291 { // No n
         helper.readArray(buffer, packet.getGamerules(), helper::readGameRule);
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v407/serializer/StartGameSerializer_v407.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v407/serializer/StartGameSerializer_v407.java
@@ -61,7 +61,7 @@ public class StartGameSerializer_v407 extends StartGameSerializer_v388 {
         helper.writeArray(buffer, packet.getGamerules(), helper::writeGameRule);
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -105,7 +105,8 @@ public class StartGameSerializer_v407 extends StartGameSerializer_v388 {
         helper.readArray(buffer, packet.getGamerules(), helper::readGameRule);
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/serializer/StartGameSerializer_v419.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/serializer/StartGameSerializer_v419.java
@@ -117,7 +117,7 @@ public class StartGameSerializer_v419 implements BedrockPacketSerializer<StartGa
         buffer.writeBoolean(packet.isExperimentsPreviouslyToggled());
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -162,7 +162,8 @@ public class StartGameSerializer_v419 implements BedrockPacketSerializer<StartGa
         packet.setExperimentsPreviouslyToggled(buffer.readBoolean());
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v465/serializer/StartGameSerializer_v465.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v465/serializer/StartGameSerializer_v465.java
@@ -46,7 +46,7 @@ public class StartGameSerializer_v465 extends StartGameSerializer_v440 {
         buffer.writeBoolean(packet.isExperimentsPreviouslyToggled());
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -94,7 +94,8 @@ public class StartGameSerializer_v465 extends StartGameSerializer_v440 {
         packet.setExperimentsPreviouslyToggled(buffer.readBoolean());
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v534/serializer/StartGameSerializer_v534.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v534/serializer/StartGameSerializer_v534.java
@@ -47,7 +47,7 @@ public class StartGameSerializer_v534 extends StartGameSerializer_v527 {
         buffer.writeBoolean(packet.isExperimentsPreviouslyToggled());
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -96,7 +96,8 @@ public class StartGameSerializer_v534 extends StartGameSerializer_v527 {
         packet.setExperimentsPreviouslyToggled(buffer.readBoolean());
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v544/serializer/StartGameSerializer_v544.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v544/serializer/StartGameSerializer_v544.java
@@ -53,7 +53,7 @@ public class StartGameSerializer_v544 extends StartGameSerializer_v534 {
         buffer.writeBoolean(packet.isExperimentsPreviouslyToggled());
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -106,7 +106,8 @@ public class StartGameSerializer_v544 extends StartGameSerializer_v534 {
         packet.setExperimentsPreviouslyToggled(buffer.readBoolean());
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v567/serializer/StartGameSerializer_v567.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v567/serializer/StartGameSerializer_v567.java
@@ -40,7 +40,7 @@ public class StartGameSerializer_v567 extends StartGameSerializer_v544 {
         buffer.writeBoolean(packet.isExperimentsPreviouslyToggled());
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -94,7 +94,8 @@ public class StartGameSerializer_v567 extends StartGameSerializer_v544 {
         packet.setExperimentsPreviouslyToggled(buffer.readBoolean());
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v582/serializer/StartGameSerializer_v582.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v582/serializer/StartGameSerializer_v582.java
@@ -54,7 +54,7 @@ public class StartGameSerializer_v582 extends StartGameSerializer_v567 {
         buffer.writeBoolean(packet.isExperimentsPreviouslyToggled());
         buffer.writeBoolean(packet.isBonusChestEnabled());
         buffer.writeBoolean(packet.isStartingWithMap());
-        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission().ordinal());
+        VarInts.writeInt(buffer, packet.getDefaultPlayerPermission() == null ? -1 : packet.getDefaultPlayerPermission().ordinal());
         buffer.writeIntLE(packet.getServerChunkTickRange());
         buffer.writeBoolean(packet.isBehaviorPackLocked());
         buffer.writeBoolean(packet.isResourcePackLocked());
@@ -110,7 +110,8 @@ public class StartGameSerializer_v582 extends StartGameSerializer_v567 {
         packet.setExperimentsPreviouslyToggled(buffer.readBoolean());
         packet.setBonusChestEnabled(buffer.readBoolean());
         packet.setStartingWithMap(buffer.readBoolean());
-        packet.setDefaultPlayerPermission(PLAYER_PERMISSIONS[VarInts.readInt(buffer)]);
+        final int ordinal = VarInts.readInt(buffer);
+        packet.setDefaultPlayerPermission(ordinal == -1 ? null : PLAYER_PERMISSIONS[ordinal]);
         packet.setServerChunkTickRange(buffer.readIntLE());
         packet.setBehaviorPackLocked(buffer.readBoolean());
         packet.setResourcePackLocked(buffer.readBoolean());


### PR DESCRIPTION
Some servers like Mineplex sent -1 for default player permission
~~~log
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 4
	at org.cloudburstmc.protocol.bedrock.codec.v567.serializer.StartGameSerializer_v567.readLevelSettings(StartGameSerializer_v567.java:97)
	at org.cloudburstmc.protocol.bedrock.codec.v428.serializer.StartGameSerializer_v428.deserialize(StartGameSerializer_v428.java:62)
	at org.cloudburstmc.protocol.bedrock.codec.v440.serializer.StartGameSerializer_v440.deserialize(StartGameSerializer_v440.java:23)
	at org.cloudburstmc.protocol.bedrock.codec.v527.serializer.StartGameSerializer_v527.deserialize(StartGameSerializer_v527.java:24)
	at org.cloudburstmc.protocol.bedrock.codec.v544.serializer.StartGameSerializer_v544.deserialize(StartGameSerializer_v544.java:21)
	at org.cloudburstmc.protocol.bedrock.codec.v544.serializer.StartGameSerializer_v544.deserialize(StartGameSerializer_v544.java:11)
	at org.cloudburstmc.protocol.bedrock.codec.BedrockCodec.tryDecode(BedrockCodec.java:57)
	... 89 more
~~~