### PR TITLE
fix: stop asserting object in writeOptional non-null

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/BedrockCodecHelper_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/BedrockCodecHelper_v291.java
@@ -374,7 +374,6 @@ public class BedrockCodecHelper_v291 extends BaseBedrockCodecHelper {
 
     @Override
     public <T> void writeOptional(ByteBuf buffer, Predicate<T> isPresent, T object, BiConsumer<ByteBuf, T> consumer) {
-        checkNotNull(object, "object");
         checkNotNull(consumer, "read consumer");
 
         boolean exists = isPresent.test(object);


### PR DESCRIPTION
some of `isPresent` performs null check