### PR TITLE
fix: accept command parameters with symbol==0

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/AvailableCommandsSerializer_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/AvailableCommandsSerializer_v291.java
@@ -232,7 +232,7 @@ public class AvailableCommandsSerializer_v291 implements BedrockPacketSerializer
         } else if (param.getType() != null) {
             symbol = this.paramTypeMap.getId(param.getType()) | ARG_FLAG_VALID;
         } else {
-            throw new IllegalStateException("No param type specified: " + param);
+            symbol = 0;
         }
 
         buffer.writeIntLE(symbol);
@@ -261,8 +261,6 @@ public class AvailableCommandsSerializer_v291 implements BedrockPacketSerializer
                 }
                 param.setType(type);
             }
-        } else {
-            throw new IllegalStateException("No param type specified: " + param.getName());
         }
 
         param.setOptional(buffer.readBoolean());


### PR DESCRIPTION
Mineplex sends AvailableCommandsPacket with parameters symbol 0, as mineplex is a featured server and vanilla client accepts this packet, i think we'd better respect this vanilla behavior.