### PR TITLE
Update Jose JWT dependency

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/SubClientLoginSerializer_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/SubClientLoginSerializer_v291.java
@@ -1,7 +1,6 @@
 package org.cloudburstmc.protocol.bedrock.codec.v291.serializer;
 
-import com.nimbusds.jose.shaded.json.JSONArray;
-import com.nimbusds.jose.shaded.json.JSONValue;
+import com.nimbusds.jose.shaded.gson.*;
 import com.nimbusds.jwt.SignedJWT;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -16,19 +15,20 @@ import org.cloudburstmc.protocol.common.util.VarInts;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 
-import static org.cloudburstmc.protocol.common.util.Preconditions.checkArgument;
+import static org.cloudburstmc.protocol.common.util.Preconditions.checkNotNull;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SubClientLoginSerializer_v291 implements BedrockPacketSerializer<SubClientLoginPacket> {
     public static final SubClientLoginSerializer_v291 INSTANCE = new SubClientLoginSerializer_v291();
+    private final Gson gson = new Gson();
 
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, SubClientLoginPacket packet) {
-        JSONArray array = new JSONArray();
+        JsonArray array = new JsonArray();
         for (SignedJWT node : packet.getChain()) {
-            array.appendElement(node.serialize());
+            array.add(node.serialize());
         }
-        String chainData = array.toJSONString();
+        String chainData = array.toString();
         int chainLength = ByteBufUtil.utf8Bytes(chainData);
         String extraData = packet.getExtra().serialize();
         int extraLength = ByteBufUtil.utf8Bytes(extraData);
@@ -44,12 +44,23 @@ public class SubClientLoginSerializer_v291 implements BedrockPacketSerializer<Su
     public void deserialize(ByteBuf buffer, BedrockCodecHelper helper, SubClientLoginPacket packet) {
         ByteBuf jwt = buffer.readSlice(VarInts.readUnsignedInt(buffer)); // Get the JWT.
 
-        Object json = JSONValue.parse(readString(jwt).array());
-        checkArgument(json instanceof JSONArray, "Expected JSON array for login chain");
+        JsonArray chain;
         try {
-            for (Object node : (JSONArray) json) {
-                checkArgument(node instanceof String, "Expected String in login chain");
-                packet.getChain().add(SignedJWT.parse((String) node));
+            JsonObject json = gson.fromJson(readString(jwt).toString(), JsonObject.class);
+            chain = checkNotNull(json.getAsJsonArray("chain"));
+        } catch (JsonSyntaxException | ClassCastException | NullPointerException exception) {
+            throw new IllegalStateException("Expected JSON array for login chain");
+        }
+
+        try {
+            for (JsonElement node : chain) {
+                String chainNode;
+                try {
+                    chainNode = node.getAsString();
+                } catch (ClassCastException | IllegalStateException exception) {
+                    throw new IllegalStateException("Expected String in login chain");
+                }
+                packet.getChain().add(SignedJWT.parse(chainNode));
             }
         } catch (ParseException e) {
             throw new IllegalArgumentException("Unable to decode JWT in login chain", e);

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/SerializedSkin.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/SerializedSkin.java
@@ -1,7 +1,7 @@
 package org.cloudburstmc.protocol.bedrock.data.skin;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
-import com.nimbusds.jose.shaded.json.JSONValue;
+import com.nimbusds.jose.shaded.gson.Gson;
+import com.nimbusds.jose.shaded.gson.JsonObject;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.*;
 
@@ -15,6 +15,7 @@ import static org.cloudburstmc.protocol.common.util.Preconditions.checkArgument;
 @EqualsAndHashCode
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class SerializedSkin {
+    private static final Gson GSON = new Gson();
     private static final int PIXEL_SIZE = 4;
 
     public static final int SINGLE_SKIN_SIZE = 64 * 32 * PIXEL_SIZE;
@@ -139,14 +140,14 @@ public class SerializedSkin {
     }
 
     private static String convertLegacyGeometryName(String geometryName) {
-        return "{\"geometry\" : {\"default\" : \"" + JSONValue.escape(geometryName) + "\"}}";
+        return "{\"geometry\" : {\"default\" : \"" + GSON.toJson(geometryName) + "\"}}";
     }
 
     private static String convertSkinPatchToLegacy(String skinResourcePatch) {
         checkArgument(validateSkinResourcePatch(skinResourcePatch), "Invalid skin resource patch");
-        JSONObject object = (JSONObject) JSONValue.parse(skinResourcePatch);
-        JSONObject geometry = (JSONObject) object.get("geometry");
-        return (String) geometry.get("default");
+        JsonObject object = GSON.fromJson(skinResourcePatch, JsonObject.class);
+        JsonObject geometry = object.getAsJsonObject("geometry");
+        return geometry.get("default").getAsString();
     }
 
     private boolean isValidResourcePatch() {
@@ -155,10 +156,11 @@ public class SerializedSkin {
 
     private static boolean validateSkinResourcePatch(String skinResourcePatch) {
         try {
-            JSONObject object = (JSONObject) JSONValue.parse(skinResourcePatch);
-            JSONObject geometry = (JSONObject) object.get("geometry");
-            return geometry.containsKey("default") && geometry.get("default") instanceof String;
-        } catch (ClassCastException | NullPointerException e) {
+            JsonObject object = GSON.fromJson(skinResourcePatch, JsonObject.class);
+            JsonObject geometry = object.getAsJsonObject("geometry");
+            geometry.get("default").getAsString();
+            return true;
+        } catch (Exception e) {
             return false;
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 checkerframework = "3.26.0"
 fastutil = "8.5.3"
 netty = "4.1.84.Final"
+jose-jwt = "9.31"
 
 [libraries]
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
@@ -15,7 +16,7 @@ fastutil-object-int-maps = { group = "com.nukkitx.fastutil", name = "fastutil-ob
 netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 netty-transport-raknet = { group = "org.cloudburstmc.netty", name = "netty-transport-raknet", version = "1.0.0.CR1-SNAPSHOT" }
 
-jose-jwt = { group = "com.nimbusds", name = "nimbus-jose-jwt", version = "9.10.1" }
+jose-jwt = { group = "com.nimbusds", name = "nimbus-jose-jwt", version.ref = "jose-jwt" }
 natives = { group = "com.nukkitx", name = "natives", version = "1.0.3" }
 math = { group = "org.cloudburstmc.math", name = "immutable", version = "2.0-SNAPSHOT" }
 nbt = { group = "org.cloudburstmc", name = "nbt", version = "3.0.0.Final" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,6 @@ dependencyResolutionManagement {
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-rootProject.name = "protocol"
+rootProject.name = "protocol-parent"
 
 include("bedrock-codec", "bedrock-connection", "common")


### PR DESCRIPTION
A dependency of mine is using a newer version of Jose JWT and because of that it couldn't find the shaded JSON Simple package, as it was replaced with Gson in a newer version.
This PR updates the dependency and moves the Jose JWT usage to Gson