### PR TITLE
Fix LevelEventGenericSerializer

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/BaseBedrockCodecHelper.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/BaseBedrockCodecHelper.java
@@ -16,6 +16,7 @@ import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
 import org.cloudburstmc.nbt.NBTInputStream;
 import org.cloudburstmc.nbt.NBTOutputStream;
+import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.nbt.NbtUtils;
 import org.cloudburstmc.protocol.bedrock.data.AbilityLayer;
 import org.cloudburstmc.protocol.bedrock.data.ExperimentData;
@@ -292,6 +293,24 @@ public abstract class BaseBedrockCodecHelper implements BedrockCodecHelper {
     public void writeTagLE(ByteBuf buffer, Object tag) {
         try (NBTOutputStream writer = NbtUtils.createWriterLE(new ByteBufOutputStream(buffer))) {
             writer.writeTag(tag);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public <T> T readTagValue(ByteBuf buffer, NbtType<T> type) {
+        try (NBTInputStream reader = NbtUtils.createNetworkReader(new ByteBufInputStream(buffer))) {
+            return reader.readValue(type);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void writeTagValue(ByteBuf buffer, Object tag) {
+        try (NBTOutputStream writer = NbtUtils.createNetworkWriter(new ByteBufOutputStream(buffer))) {
+            writer.writeValue(tag);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/BedrockCodecHelper.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/BedrockCodecHelper.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import org.cloudburstmc.math.vector.Vector2f;
 import org.cloudburstmc.math.vector.Vector3f;
 import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.data.AbilityLayer;
 import org.cloudburstmc.protocol.bedrock.data.ExperimentData;
 import org.cloudburstmc.protocol.bedrock.data.GameRuleData;
@@ -164,6 +165,10 @@ public interface BedrockCodecHelper {
     <T> T readTagLE(ByteBuf buffer, Class<T> expected);
 
     void writeTagLE(ByteBuf buffer, Object tag);
+
+    <T> T readTagValue(ByteBuf buffer, NbtType<T> type);
+
+    void writeTagValue(ByteBuf buffer, Object tag);
 
     void readItemUse(ByteBuf buffer, InventoryTransactionPacket packet);
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v361/serializer/LevelEventGenericSerializer_v361.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v361/serializer/LevelEventGenericSerializer_v361.java
@@ -2,6 +2,7 @@ package org.cloudburstmc.protocol.bedrock.codec.v361.serializer;
 
 import io.netty.buffer.ByteBuf;
 import lombok.RequiredArgsConstructor;
+import org.cloudburstmc.nbt.NbtType;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockPacketSerializer;
 import org.cloudburstmc.protocol.bedrock.data.LevelEventType;
@@ -17,13 +18,13 @@ public class LevelEventGenericSerializer_v361 implements BedrockPacketSerializer
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, LevelEventGenericPacket packet) {
         VarInts.writeInt(buffer, typeMap.getId(packet.getType()));
-        helper.writeTag(buffer, packet.getTag());
+        helper.writeTagValue(buffer, packet.getTag());
     }
 
     @Override
     public void deserialize(ByteBuf buffer, BedrockCodecHelper helper, LevelEventGenericPacket packet) {
         int eventId = VarInts.readInt(buffer);
         packet.setType(typeMap.getType(eventId));
-        packet.setTag(helper.readTag(buffer, Object.class));
+        packet.setTag(helper.readTagValue(buffer, NbtType.COMPOUND));
     }
 }


### PR DESCRIPTION
Based on https://github.com/CloudburstMC/Protocol/commit/86c5d03740ba5b1a71745272bc545cc737e37075 in Protocol 2

Seems to work fine with ProxyPass and BDS 1.19.81.01