### PR TITLE
Move away from jose jwt to jose4j

### DIFF
--- a/bedrock-codec/build.gradle.kts
+++ b/bedrock-codec/build.gradle.kts
@@ -3,7 +3,7 @@ dependencies {
     api(libs.netty.buffer)
     api(libs.fastutil.long.common)
     api(libs.fastutil.long.`object`.maps)
-    api(libs.jose.jwt)
+    api(libs.jose4j)
     api(libs.nbt)
 }
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/SerializedSkin.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/SerializedSkin.java
@@ -1,9 +1,9 @@
 package org.cloudburstmc.protocol.bedrock.data.skin;
 
-import com.nimbusds.jose.shaded.json.JSONObject;
-import com.nimbusds.jose.shaded.json.JSONValue;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.*;
+import org.jose4j.json.internal.json_simple.JSONObject;
+import org.jose4j.json.internal.json_simple.JSONValue;
 
 import java.util.Collections;
 import java.util.List;

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/LoginPacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/LoginPacket.java
@@ -1,6 +1,5 @@
 package org.cloudburstmc.protocol.bedrock.packet;
 
-import com.nimbusds.jwt.SignedJWT;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -14,8 +13,8 @@ import java.util.List;
 @ToString(doNotUseGetters = true)
 public class LoginPacket implements BedrockPacket {
     private int protocolVersion;
-    private final List<SignedJWT> chain = new ArrayList<>();
-    private SignedJWT extra;
+    private final List<String> chain = new ArrayList<>();
+    private String extra;
 
     @Override
     public final PacketSignal handle(BedrockPacketHandler handler) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/SubClientLoginPacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/SubClientLoginPacket.java
@@ -1,6 +1,5 @@
 package org.cloudburstmc.protocol.bedrock.packet;
 
-import com.nimbusds.jwt.SignedJWT;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -13,8 +12,8 @@ import java.util.List;
 @EqualsAndHashCode(doNotUseGetters = true)
 @ToString(doNotUseGetters = true)
 public class SubClientLoginPacket implements BedrockPacket {
-    private final List<SignedJWT> chain = new ArrayList<>();
-    private SignedJWT extra;
+    private final List<String> chain = new ArrayList<>();
+    private String extra;
 
     @Override
     public final PacketSignal handle(BedrockPacketHandler handler) {

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/ChainValidationResult.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/ChainValidationResult.java
@@ -1,0 +1,96 @@
+package org.cloudburstmc.protocol.bedrock.util;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jose4j.json.JsonUtil;
+import org.jose4j.lang.JoseException;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.cloudburstmc.protocol.bedrock.util.JsonUtils.childAsType;
+
+public final class ChainValidationResult {
+    private final boolean signed;
+    private final Map<String, Object> parsedPayload;
+
+    private IdentityClaims identityClaims;
+
+    public ChainValidationResult(boolean signed, String rawPayload) throws JoseException {
+        this(signed, JsonUtil.parseJson(rawPayload));
+    }
+
+    public ChainValidationResult(boolean signed, Map<String, Object> parsedPayload) {
+        this.signed = signed;
+        this.parsedPayload = Objects.requireNonNull(parsedPayload);
+    }
+
+    public boolean signed() {
+        return signed;
+    }
+
+    public Map<String, Object> rawIdentityClaims() {
+        return new HashMap<>(parsedPayload);
+    }
+
+    public IdentityClaims identityClaims() throws IllegalStateException {
+        if (identityClaims == null) {
+            String identityPublicKey = childAsType(parsedPayload, "identityPublicKey", String.class);
+            Map<?, ?> extraData = childAsType(parsedPayload, "extraData", Map.class);
+
+            String displayName = childAsType(extraData, "displayName", String.class);
+            String identityString = childAsType(extraData, "identity", String.class);
+            String xuid = childAsType(extraData, "XUID", String.class);
+            Object titleId = extraData.get("titleId");
+
+            UUID identity;
+            try {
+                identity = UUID.fromString(identityString);
+            } catch (Exception exception) {
+                throw new IllegalStateException("identity node is an invalid UUID");
+            }
+
+            identityClaims = new IdentityClaims(
+                    new IdentityData(displayName, identity, xuid, (String) titleId),
+                    identityPublicKey
+            );
+        }
+        return identityClaims;
+    }
+
+    public static final class IdentityClaims {
+        public final IdentityData extraData;
+        public final String identityPublicKey;
+        private PublicKey parsedIdentityPublicKey;
+
+        private IdentityClaims(IdentityData extraData, String identityPublicKey) {
+            this.extraData = extraData;
+            this.identityPublicKey = identityPublicKey;
+        }
+
+        public PublicKey parsedIdentityPublicKey() throws NoSuchAlgorithmException, InvalidKeySpecException {
+            if (parsedIdentityPublicKey == null) {
+                parsedIdentityPublicKey = EncryptionUtils.parseKey(identityPublicKey);
+            }
+            return parsedIdentityPublicKey;
+        }
+    }
+
+    public static final class IdentityData {
+        public final String displayName;
+        public final UUID identity;
+        public final String xuid;
+        public final @Nullable String titleId;
+
+        private IdentityData(String displayName, UUID identity, String xuid, @Nullable String titleId) {
+            this.displayName = displayName;
+            this.identity = identity;
+            this.xuid = xuid;
+            this.titleId = titleId;
+        }
+    }
+}

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
@@ -29,8 +29,12 @@ import java.util.Map;
 @UtilityClass
 public class EncryptionUtils {
     private static final ECPublicKey MOJANG_PUBLIC_KEY;
+    private static final ECPublicKey OLD_MOJANG_PUBLIC_KEY;
+
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final String MOJANG_PUBLIC_KEY_BASE64 =
+            "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECRXueJeTDqNRRgJi/vlRufByu/2G0i2Ebt6YMar5QX/R0DIIyrJMcUpruK4QveTfJSTp3Shlq4Gk34cD/4GUWwkv0DVuzeuB+tXija7HBxii03NHDbPAD0AKnLr2wdAp";
+    private static final String OLD_MOJANG_PUBLIC_KEY_BASE64 =
             "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8ELkixyLcwlZryUQcu1TvPOmI2B7vX83ndnWRUaXm74wFfa5f/lwQNTfrLVHa2PmenpGI6JhIMUJaWZrjmMj90NoKNFSNBuKdm8rYiXsfaz3K36x/1U26HpG0ZxK/V1V";
     private static final KeyPairGenerator KEY_PAIR_GEN;
 
@@ -48,6 +52,7 @@ public class EncryptionUtils {
             KEY_PAIR_GEN = KeyPairGenerator.getInstance("EC");
             KEY_PAIR_GEN.initialize(new ECGenParameterSpec("secp384r1"));
             MOJANG_PUBLIC_KEY = parseKey(MOJANG_PUBLIC_KEY_BASE64);
+            OLD_MOJANG_PUBLIC_KEY = parseKey(OLD_MOJANG_PUBLIC_KEY_BASE64);
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeySpecException e) {
             throw new AssertionError("Unable to initialize required encryption", e);
         }
@@ -119,7 +124,7 @@ public class EncryptionUtils {
                     }
 
                     // the second chain entry has to be signed by Mojang
-                    if (i == 1 && !currentKey.equals(MOJANG_PUBLIC_KEY)) {
+                    if (i == 1 && (!currentKey.equals(MOJANG_PUBLIC_KEY) || !currentKey.equals(OLD_MOJANG_PUBLIC_KEY))) {
                         throw new IllegalStateException("The chain isn't signed by Mojang!");
                     }
 

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/JsonUtils.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/JsonUtils.java
@@ -1,0 +1,14 @@
+package org.cloudburstmc.protocol.bedrock.util;
+
+import java.util.Map;
+
+public class JsonUtils {
+    @SuppressWarnings("unchecked")
+    public static  <T> T childAsType(Map<?, ?> data, String key, Class<T> asType) {
+        Object value = data.get(key);
+        if (!(asType.isInstance(value))) {
+            throw new IllegalStateException(key + " node is missing");
+        }
+        return (T) value;
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ fastutil-object-int-maps = { group = "com.nukkitx.fastutil", name = "fastutil-ob
 netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 netty-transport-raknet = { group = "org.cloudburstmc.netty", name = "netty-transport-raknet", version = "1.0.0.CR1-SNAPSHOT" }
 
-jose-jwt = { group = "com.nimbusds", name = "nimbus-jose-jwt", version = "9.10.1" }
+jose4j = { group = "org.bitbucket.b_c", name = "jose4j", version = "0.9.3" }
 natives = { group = "com.nukkitx", name = "natives", version = "1.0.3" }
 math = { group = "org.cloudburstmc.math", name = "immutable", version = "2.0-SNAPSHOT" }
 nbt = { group = "org.cloudburstmc", name = "nbt", version = "3.0.0.Final" }


### PR DESCRIPTION
I originally updated the jose jwt library version in #199, but was decided against since it'd bundle Gson which is a relatively large json library.
The idea came up to move to an other JWT library which still uses json simple (orgjson) and ultimately ended up with jose4j.
I also included some other changes to EncryptionUtils to make it more useful for projects using Protocol.