### PR TITLE
Document the serialiser version for 1.20.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Check out [EXAMPLES.md](EXAMPLES.md) for examples on how to use this library.
 | Bedrock_v622 |  1.20.40 - 1.20.41  |
 | Bedrock_v630 |  1.20.50 - 1.20.51  |
 | Bedrock_v649 |       1.20.60       |
+| Bedrock_v662 |  1.20.70 - 1.20.72  |
 
 ##### Repository:
 


### PR DESCRIPTION
README.md did not contain the serialiser for Minecraft Versions 1.20.70 - 1.20.72 (Protocol Version 662).

This pull request aims to add the missing serialiser version in the README.md for Bedrock Protocol Codec 662