### PR TITLE
Upgrade Jose4j version because of CVE-2023-51775

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+
+*.sh text eol=lf
+gradlew text eol=lf
+*.bat text eol=crlf
+
+*.jar binary

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ fastutil-object-int-maps = { group = "org.cloudburstmc.fastutil.maps", name = "o
 netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 netty-transport-raknet = { group = "org.cloudburstmc.netty", name = "netty-transport-raknet", version = "1.0.0.CR1-SNAPSHOT" }
 
-jose4j = { group = "org.bitbucket.b_c", name = "jose4j", version = "0.9.3" }
+jose4j = { group = "org.bitbucket.b_c", name = "jose4j", version = "0.9.6" }
 natives = { group = "com.nukkitx", name = "natives", version = "1.0.3" }
 math = { group = "org.cloudburstmc.math", name = "immutable", version = "2.0-SNAPSHOT" }
 nbt = { group = "org.cloudburstmc", name = "nbt", version = "3.0.2.Final" }

--- a/gradlew
+++ b/gradlew
@@ -205,12 +205,6 @@ set -- \
         org.gradle.wrapper.GradleWrapperMain \
         "$@"
 
-# Stop when "xargs" is not available.
-if ! command -v xargs >/dev/null 2>&1
-then
-    die "xargs is not available"
-fi
-
 # Use "xargs" to parse quoted args.
 #
 # With -n1 it outputs one arg per line, with the quotes and backslashes removed.


### PR DESCRIPTION
Upgrade Jose4j version and make gradlew executable again on unix systems.