### PR TITLE
Move packet logging behind debug

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/EntityEventSerializer_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/EntityEventSerializer_v291.java
@@ -31,7 +31,7 @@ public class EntityEventSerializer_v291 implements BedrockPacketSerializer<Entit
         int event = buffer.readUnsignedByte();
         packet.setType(this.typeMap.getType(event));
         packet.setData(VarInts.readInt(buffer));
-        if (packet.getType() == null) {
+        if (log.isDebugEnabled() && packet.getType() == null) {
             log.debug("Unknown EntityEvent {} in packet {}", event, packet);
         }
     }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v361/BedrockCodecHelper_v361.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v361/BedrockCodecHelper_v361.java
@@ -82,9 +82,9 @@ public class BedrockCodecHelper_v361 extends BedrockCodecHelper_v340 {
                         entityDataMap.put(definition.getType(), transformer.deserialize(this, entityDataMap, value));
                     }
                 }
-            } else {
-                log.debug("Unknown entity data: {} type {} value {}", id, format, value);
             }
+            
+            log.debug("Unknown entity data: {} type {} value {}", id, format, value);
         }
     }
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v361/BedrockCodecHelper_v361.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v361/BedrockCodecHelper_v361.java
@@ -82,9 +82,9 @@ public class BedrockCodecHelper_v361 extends BedrockCodecHelper_v340 {
                         entityDataMap.put(definition.getType(), transformer.deserialize(this, entityDataMap, value));
                     }
                 }
+            } else {
+                log.debug("Unknown entity data: {} type {} value {}", id, format, value);
             }
-            
-            log.debug("Unknown entity data: {} type {} value {}", id, format, value);
         }
     }
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v431/BedrockCodecHelper_v431.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v431/BedrockCodecHelper_v431.java
@@ -149,9 +149,12 @@ public class BedrockCodecHelper_v431 extends BedrockCodecHelper_v428 {
             throw new IllegalStateException("Unable to read item user data", e);
         }
 
-        if (log.isDebugEnabled() && buf.isReadable()) {
-            log.debug("Item user data has {} readable bytes left", buf.readableBytes());
-            log.debug("Item data:\n{}", ByteBufUtil.prettyHexDump(buf.readerIndex(0)));
+        if (buf.isReadable()) {
+            log.info("Item user data has {} readable bytes left", buf.readableBytes());
+
+            if (log.isDebugEnabled()) {
+                log.debug("Item data:\n{}", ByteBufUtil.prettyHexDump(buf.readerIndex(0)));
+            }
         }
 
         return ItemData.builder()

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v431/BedrockCodecHelper_v431.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v431/BedrockCodecHelper_v431.java
@@ -79,11 +79,9 @@ public class BedrockCodecHelper_v431 extends BedrockCodecHelper_v428 {
             throw new IllegalStateException("Unable to read item user data", e);
         }
 
-        if (buf.isReadable()) {
-            log.info("Item user data has {} readable bytes left", buf.readableBytes());
-            if (log.isDebugEnabled()) {
-                log.debug("Item data:\n{}", ByteBufUtil.prettyHexDump(buf.readerIndex(0)));
-            }
+        if (log.isDebugEnabled() && buf.isReadable()) {
+            log.debug("Item user data has {} readable bytes left", buf.readableBytes());
+            log.debug("Item data:\n{}", ByteBufUtil.prettyHexDump(buf.readerIndex(0)));
         }
 
         return ItemData.builder()
@@ -151,11 +149,9 @@ public class BedrockCodecHelper_v431 extends BedrockCodecHelper_v428 {
             throw new IllegalStateException("Unable to read item user data", e);
         }
 
-        if (buf.isReadable()) {
-            log.info("Item user data has {} readable bytes left", buf.readableBytes());
-            if (log.isDebugEnabled()) {
-                log.debug("Item data:\n{}", ByteBufUtil.prettyHexDump(buf.readerIndex(0)));
-            }
+        if (log.isDebugEnabled() && buf.isReadable()) {
+            log.debug("Item user data has {} readable bytes left", buf.readableBytes());
+            log.debug("Item data:\n{}", ByteBufUtil.prettyHexDump(buf.readerIndex(0)));
         }
 
         return ItemData.builder()

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/StartGamePacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/StartGamePacket.java
@@ -1,7 +1,5 @@
 package org.cloudburstmc.protocol.bedrock.packet;
 
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -23,8 +21,6 @@ import java.util.UUID;
 @EqualsAndHashCode(doNotUseGetters = true)
 @ToString(doNotUseGetters = true, exclude = {"itemDefinitions", "blockPalette"})
 public class StartGamePacket implements BedrockPacket {
-    private static final InternalLogger log = InternalLoggerFactory.getInstance(StartGamePacket.class);
-
     private final List<GameRuleData<?>> gamerules = new ObjectArrayList<>();
     private long uniqueEntityId;
     private long runtimeEntityId;

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockSession.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockSession.java
@@ -111,10 +111,13 @@ public abstract class BedrockSession {
     protected void onPacket(BedrockPacketWrapper wrapper) {
         BedrockPacket packet = wrapper.getPacket();
         this.logInbound(packet);
+
+        if (!log.isDebugEnabled()) return;
+
         if (packetHandler == null) {
-            log.warn("Received packet without a packet handler for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
+            log.debug("Received packet without a packet handler for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
         } else if (this.packetHandler.handlePacket(packet) == PacketSignal.UNHANDLED) {
-            log.warn("Unhandled packet for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
+            log.debug("Unhandled packet for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
         }
     }
 

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockSession.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockSession.java
@@ -112,8 +112,6 @@ public abstract class BedrockSession {
         BedrockPacket packet = wrapper.getPacket();
         this.logInbound(packet);
 
-        if (!log.isDebugEnabled()) return;
-
         if (packetHandler == null) {
             log.debug("Received packet without a packet handler for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
         } else if (this.packetHandler.handlePacket(packet) == PacketSignal.UNHANDLED) {

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockSession.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockSession.java
@@ -113,9 +113,13 @@ public abstract class BedrockSession {
         this.logInbound(packet);
 
         if (packetHandler == null) {
-            log.debug("Received packet without a packet handler for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
+            if (log.isDebugEnabled()) {
+                log.debug("Received packet without a packet handler for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
+            }
         } else if (this.packetHandler.handlePacket(packet) == PacketSignal.UNHANDLED) {
-            log.debug("Unhandled packet for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);
+            if (log.isDebugEnabled()) {
+                log.debug("Unhandled packet for {}:{}: {}", this.getSocketAddress(), this.subClientId, packet);   
+            }
         }
     }
 

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/codec/batch/BedrockBatchEncoder.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/codec/batch/BedrockBatchEncoder.java
@@ -5,8 +5,6 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.cloudburstmc.protocol.bedrock.netty.BedrockBatchWrapper;
 import org.cloudburstmc.protocol.bedrock.netty.BedrockPacketWrapper;
 import org.cloudburstmc.protocol.common.util.VarInts;
@@ -17,8 +15,6 @@ import java.util.Queue;
 public class BedrockBatchEncoder extends ChannelOutboundHandlerAdapter {
 
     public static final String NAME = "bedrock-batch-encoder";
-
-    private static final InternalLogger log = InternalLoggerFactory.getInstance(BedrockBatchEncoder.class);
 
     private final Queue<BedrockPacketWrapper> messages = new ArrayDeque<>();
 

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/codec/packet/BedrockPacketCodec.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/codec/packet/BedrockPacketCodec.java
@@ -3,7 +3,6 @@ package org.cloudburstmc.protocol.bedrock.netty.codec.packet;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToMessageCodec;
-import io.netty.util.Attribute;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import org.cloudburstmc.protocol.bedrock.PacketDirection;
@@ -52,7 +51,7 @@ public abstract class BedrockPacketCodec extends MessageToMessageCodec<ByteBuf, 
                 msg.setPacketBuffer(buf.retain());
                 out.add(msg.retain());
             } catch (Throwable t) {
-                log.error("Error encoding packet {}", msg.getPacket(), t);
+                log.debug("Error encoding packet {}", msg.getPacket(), t);
             } finally {
                 buf.release();
             }
@@ -70,7 +69,7 @@ public abstract class BedrockPacketCodec extends MessageToMessageCodec<ByteBuf, 
             wrapper.setPacket(this.codec.tryDecode(helper, msg, wrapper.getPacketId(), this.inboundRecipient));
             out.add(wrapper.retain());
         } catch (Throwable t) {
-            log.info("Failed to decode packet", t);
+            log.debug("Failed to decode packet", t);
             throw t;
         } finally {
             wrapper.release();

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/codec/packet/BedrockPacketCodec.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/codec/packet/BedrockPacketCodec.java
@@ -51,7 +51,9 @@ public abstract class BedrockPacketCodec extends MessageToMessageCodec<ByteBuf, 
                 msg.setPacketBuffer(buf.retain());
                 out.add(msg.retain());
             } catch (Throwable t) {
-                log.debug("Error encoding packet {}", msg.getPacket(), t);
+                if (log.isDebugEnabled()) {
+                    log.debug("Error encoding packet {}", msg.getPacket(), t);
+                }
             } finally {
                 buf.release();
             }
@@ -69,7 +71,9 @@ public abstract class BedrockPacketCodec extends MessageToMessageCodec<ByteBuf, 
             wrapper.setPacket(this.codec.tryDecode(helper, msg, wrapper.getPacketId(), this.inboundRecipient));
             out.add(wrapper.retain());
         } catch (Throwable t) {
-            log.debug("Failed to decode packet", t);
+            if (log.isDebugEnabled()) {
+                log.debug("Failed to decode packet", t);
+            }
             throw t;
         } finally {
             wrapper.release();

--- a/common/src/main/java/org/cloudburstmc/protocol/common/util/TypeMap.java
+++ b/common/src/main/java/org/cloudburstmc/protocol/common/util/TypeMap.java
@@ -1,7 +1,5 @@
 package org.cloudburstmc.protocol.common.util;
 
-import io.netty.util.internal.logging.InternalLogger;
-import io.netty.util.internal.logging.InternalLoggerFactory;
 import it.unimi.dsi.fastutil.ints.*;
 import it.unimi.dsi.fastutil.objects.Object2IntMap;
 import it.unimi.dsi.fastutil.objects.Object2IntMaps;
@@ -19,8 +17,6 @@ import static org.cloudburstmc.protocol.common.util.Preconditions.checkArgument;
 import static org.cloudburstmc.protocol.common.util.Preconditions.checkNotNull;
 
 public final class TypeMap<T> {
-
-    private static final InternalLogger log = InternalLoggerFactory.getInstance(TypeMap.class);
 
     private final String type;
     private final Object2IntMap<T> toId;


### PR DESCRIPTION
Moves all packet logging behind log.debug so that library users can choose how things are logged.