### PR TITLE
Increase size caps in some places (animation size, geometry size etc.)

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v388/BedrockCodecHelper_v388.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v388/BedrockCodecHelper_v388.java
@@ -77,7 +77,7 @@ public class BedrockCodecHelper_v388 extends BedrockCodecHelper_v361 {
 
     @Override
     public AnimationData readAnimationData(ByteBuf buffer) {
-        ImageData image = this.readImage(buffer, ImageData.SKIN_128_128_SIZE);
+        ImageData image = this.readImage(buffer, ImageData.ANIMATION_SIZE);
         AnimatedTextureType type = TEXTURE_TYPES[buffer.readIntLE()];
         float frames = buffer.readFloatLE();
         return new AnimationData(image, type, frames);

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/BedrockCodecHelper_v419.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/BedrockCodecHelper_v419.java
@@ -46,7 +46,7 @@ public class BedrockCodecHelper_v419 extends BedrockCodecHelper_v407 {
 
     @Override
     public AnimationData readAnimationData(ByteBuf buffer) {
-        ImageData image = this.readImage(buffer, ImageData.SKIN_128_128_SIZE);
+        ImageData image = this.readImage(buffer, ImageData.ANIMATION_SIZE);
         AnimatedTextureType textureType = TEXTURE_TYPES[buffer.readIntLE()];
         float frames = buffer.readFloatLE();
         AnimationExpressionType expressionType = EXPRESSION_TYPES[buffer.readIntLE()];

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/EncodingSettings.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/EncodingSettings.java
@@ -32,7 +32,7 @@ public class EncodingSettings {
             .maxByteArraySize(1024 * 1024 * 20) // 20MB
             .maxNetworkNBTSize(1024 * 1024 * 10) // 10MB
             .maxItemNBTSize(1024 * 1024 * 5) // 5MB
-            .maxStringLength(1024 * 1024) // 1MB
+            .maxStringLength(1024 * 1024 * 2) // 2MB
             .build();
 
     /**

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/ImageData.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/ImageData.java
@@ -21,6 +21,7 @@ public class ImageData {
     public static final int SKIN_128_64_SIZE = 128 * 64 * PIXEL_SIZE;
     public static final int SKIN_128_128_SIZE = 128 * 128 * PIXEL_SIZE;
     public static final int SKIN_PERSONA_SIZE = 256 * 256 * PIXEL_SIZE;
+    public static final int ANIMATION_SIZE = 1024 * 1024; // 1 MB
 
     private final int width;
     private final int height;


### PR DESCRIPTION
Linked to the https://github.com/CloudburstMC/Protocol/issues/230.

Outstanding cases that I have encountered so far:
[BedrockCodecHelper_v419.java:49](https://github.com/CloudburstMC/Protocol/blob/68dc192f8ebca6d76c486e53d04a6f91187d62e9/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/BedrockCodecHelper_v419.java#L49)
```
** v_419 reading an image when reading an animation data (512kb)** 
Caused by: java.lang.IllegalArgumentException: Tried to read 524288 bytes but maximum is 65536
	at org.cloudburstmc.protocol.common.util.Preconditions.checkArgument(Preconditions.java:291) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readByteArray(BaseBedrockCodecHelper.java:86) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v388.BedrockCodecHelper_v388.readImage(BedrockCodecHelper_v388.java:97) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v419.BedrockCodecHelper_v419.readAnimationData(BedrockCodecHelper_v419.java:49) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v568.BedrockCodecHelper_v568.lambda$readSkin$0(BedrockCodecHelper_v568.java:32) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readArray(BaseBedrockCodecHelper.java:221) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readArray(BaseBedrockCodecHelper.java:212) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v568.BedrockCodecHelper_v568.readSkin(BedrockCodecHelper_v568.java:32) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.readEntryBase(PlayerListSerializer_v390.java:79) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v649.serializer.PlayerListSerializer_v649.readEntryBase(PlayerListSerializer_v649.java:22) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.deserialize(PlayerListSerializer_v390.java:46) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.deserialize(PlayerListSerializer_v390.java:14) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BedrockCodec.tryDecode(BedrockCodec.java:68) ~[Waterdog.jar:?]
	... 89 more
```
[BedrockCodecHelper_v419.java:49](https://github.com/CloudburstMC/Protocol/blob/68dc192f8ebca6d76c486e53d04a6f91187d62e9/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v419/BedrockCodecHelper_v419.java#L49)
```
** same, but another size (1 MB)
Caused by: java.lang.IllegalArgumentException: Tried to read 1048576 bytes but maximum is 65536
	at org.cloudburstmc.protocol.common.util.Preconditions.checkArgument(Preconditions.java:291) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readByteArray(BaseBedrockCodecHelper.java:86) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v388.BedrockCodecHelper_v388.readImage(BedrockCodecHelper_v388.java:97) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v419.BedrockCodecHelper_v419.readAnimationData(BedrockCodecHelper_v419.java:49) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v568.BedrockCodecHelper_v568.lambda$readSkin$0(BedrockCodecHelper_v568.java:32) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readArray(BaseBedrockCodecHelper.java:221) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readArray(BaseBedrockCodecHelper.java:212) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v568.BedrockCodecHelper_v568.readSkin(BedrockCodecHelper_v568.java:32) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.readEntryBase(PlayerListSerializer_v390.java:79) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v649.serializer.PlayerListSerializer_v649.readEntryBase(PlayerListSerializer_v649.java:22) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.deserialize(PlayerListSerializer_v390.java:46) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.deserialize(PlayerListSerializer_v390.java:14) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BedrockCodec.tryDecode(BedrockCodec.java:68) ~[Waterdog.jar:?]
	... 92 more
```
[BedrockCodecHelper_v568.java:35](https://github.com/CloudburstMC/Protocol/blob/68dc192f8ebca6d76c486e53d04a6f91187d62e9/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v568/BedrockCodecHelper_v568.java#L35)
```
Tried to read geometry data (2 MB, max was 1mb)
Caused by: java.lang.IllegalArgumentException: Tried to read 2180462 bytes but maximum is 1048576
	at org.cloudburstmc.protocol.common.util.Preconditions.checkArgument(Preconditions.java:291) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BaseBedrockCodecHelper.readString(BaseBedrockCodecHelper.java:113) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v568.BedrockCodecHelper_v568.readSkin(BedrockCodecHelper_v568.java:35) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.readEntryBase(PlayerListSerializer_v390.java:79) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.deserialize(PlayerListSerializer_v390.java:46) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.v390.serializer.PlayerListSerializer_v390.deserialize(PlayerListSerializer_v390.java:14) ~[Waterdog.jar:?]
	at org.cloudburstmc.protocol.bedrock.codec.BedrockCodec.tryDecode(BedrockCodec.java:68) ~[Waterdog.jar:?]
	... 89 more
```