### PR TITLE
Update to Fastutil release

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     api(libs.netty.buffer)
+    api(enforcedPlatform(libs.fastutil.bom))
     api(libs.fastutil.int.`object`.maps)
     api(libs.fastutil.`object`.int.maps)
     api(libs.math)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 checkerframework = "3.37.0"
-fastutil = "8.5.13-SNAPSHOT"
 netty = "4.1.101.Final"
 
 [libraries]
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
 checker = { group = "org.checkerframework", name = "checker", version.ref = "checkerframework" }
 
-fastutil-long-common = { group = "org.cloudburstmc.fastutil.commons", name = "long-common", version.ref = "fastutil" }
-fastutil-long-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "long-object-maps", version.ref = "fastutil" }
-fastutil-int-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "int-object-maps", version.ref = "fastutil" }
-fastutil-object-int-maps = { group = "org.cloudburstmc.fastutil.maps", name = "object-int-maps", version.ref = "fastutil" }
+fastutil-bom = { group = "org.cloudburstmc.fastutil", name = "bom", version = "8.5.13" }
+fastutil-long-common = { group = "org.cloudburstmc.fastutil.commons", name = "long-common" }
+fastutil-long-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "long-object-maps" }
+fastutil-int-object-maps = { group = "org.cloudburstmc.fastutil.maps", name = "int-object-maps" }
+fastutil-object-int-maps = { group = "org.cloudburstmc.fastutil.maps", name = "object-int-maps" }
 
 netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
 netty-transport-raknet = { group = "org.cloudburstmc.netty", name = "netty-transport-raknet", version = "1.0.0.CR3-SNAPSHOT" }


### PR DESCRIPTION
Update from `8.5.13-SNAPSHOT` to `8.5.13` release, and enforce BOM to ensure versioning is consistent.