### PR TITLE
Fix ContainerCloseSerializer_v685

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v685/serializer/ContainerCloseSerializer_v685.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v685/serializer/ContainerCloseSerializer_v685.java
@@ -12,7 +12,7 @@ public class ContainerCloseSerializer_v685 implements BedrockPacketSerializer<Co
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, ContainerClosePacket packet) {
         buffer.writeByte(packet.getId());
-        buffer.writeByte(packet.getType().ordinal());
+        buffer.writeByte(packet.getType().getId());
         buffer.writeBoolean(packet.isServerInitiated());
     }
 


### PR DESCRIPTION
Changes the type id being written to the actual container type id instead of the enum ordinal