### PR TITLE
Remove the old Mojang key

### DIFF
--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
@@ -29,13 +29,10 @@ import java.util.Map;
 @UtilityClass
 public class EncryptionUtils {
     private static final ECPublicKey MOJANG_PUBLIC_KEY;
-    private static final ECPublicKey OLD_MOJANG_PUBLIC_KEY;
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final String MOJANG_PUBLIC_KEY_BASE64 =
             "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECRXueJeTDqNRRgJi/vlRufByu/2G0i2Ebt6YMar5QX/R0DIIyrJMcUpruK4QveTfJSTp3Shlq4Gk34cD/4GUWwkv0DVuzeuB+tXija7HBxii03NHDbPAD0AKnLr2wdAp";
-    private static final String OLD_MOJANG_PUBLIC_KEY_BASE64 =
-            "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8ELkixyLcwlZryUQcu1TvPOmI2B7vX83ndnWRUaXm74wFfa5f/lwQNTfrLVHa2PmenpGI6JhIMUJaWZrjmMj90NoKNFSNBuKdm8rYiXsfaz3K36x/1U26HpG0ZxK/V1V";
     private static final KeyPairGenerator KEY_PAIR_GEN;
 
     public static final String ALGORITHM_TYPE = AlgorithmIdentifiers.ECDSA_USING_P384_CURVE_AND_SHA384;
@@ -52,7 +49,6 @@ public class EncryptionUtils {
             KEY_PAIR_GEN = KeyPairGenerator.getInstance("EC");
             KEY_PAIR_GEN.initialize(new ECGenParameterSpec("secp384r1"));
             MOJANG_PUBLIC_KEY = parseKey(MOJANG_PUBLIC_KEY_BASE64);
-            OLD_MOJANG_PUBLIC_KEY = parseKey(OLD_MOJANG_PUBLIC_KEY_BASE64);
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeySpecException e) {
             throw new AssertionError("Unable to initialize required encryption", e);
         }
@@ -124,7 +120,7 @@ public class EncryptionUtils {
                     }
 
                     // the second chain entry has to be signed by Mojang
-                    if (i == 1 && (!currentKey.equals(MOJANG_PUBLIC_KEY) && !currentKey.equals(OLD_MOJANG_PUBLIC_KEY))) {
+                    if (i == 1 && !currentKey.equals(MOJANG_PUBLIC_KEY)) {
                         throw new IllegalStateException("The chain isn't signed by Mojang!");
                     }
 


### PR DESCRIPTION
The new one has been in use for a while now, there is no need to keep the old one and there probably was a reason why they switched over in the first place.