### PR TITLE
Fix using wrong data type for Client Interact Prediction

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v712/BedrockCodecHelper_v712.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v712/BedrockCodecHelper_v712.java
@@ -133,7 +133,7 @@ public class BedrockCodecHelper_v712 extends BedrockCodecHelper_v575 {
         this.writeVector3f(buffer, packet.getPlayerPosition());
         this.writeVector3f(buffer, packet.getClickPosition());
         VarInts.writeUnsignedInt(buffer, packet.getBlockDefinition().getRuntimeId());
-        VarInts.writeUnsignedInt(buffer, packet.getClientInteractPrediction().ordinal());
+        buffer.writeByte(packet.getClientInteractPrediction().ordinal());
     }
 
     @Override
@@ -147,7 +147,7 @@ public class BedrockCodecHelper_v712 extends BedrockCodecHelper_v575 {
         packet.setPlayerPosition(this.readVector3f(buffer));
         packet.setClickPosition(this.readVector3f(buffer));
         packet.setBlockDefinition(this.blockDefinitions.getDefinition(VarInts.readUnsignedInt(buffer)));
-        packet.setClientInteractPrediction(ItemUseTransaction.PredictedResult.values()[VarInts.readUnsignedInt(buffer)]);
+        packet.setClientInteractPrediction(ItemUseTransaction.PredictedResult.values()[buffer.readByte()]);
     }
 
     protected void writeFullContainerName(ByteBuf buffer, FullContainerName containerName) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v712/serializer/PlayerAuthInputSerializer_v712.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v712/serializer/PlayerAuthInputSerializer_v712.java
@@ -32,7 +32,7 @@ public class PlayerAuthInputSerializer_v712 extends PlayerAuthInputSerializer_v6
         helper.writeVector3f(buffer, transaction.getPlayerPosition());
         helper.writeVector3f(buffer, transaction.getClickPosition());
         VarInts.writeUnsignedInt(buffer, transaction.getBlockDefinition().getRuntimeId());
-        VarInts.writeUnsignedInt(buffer, transaction.getClientInteractPrediction().ordinal());
+        buffer.writeByte(transaction.getClientInteractPrediction().ordinal());
     }
 
     @Override
@@ -60,7 +60,7 @@ public class PlayerAuthInputSerializer_v712 extends PlayerAuthInputSerializer_v6
         itemTransaction.setPlayerPosition(helper.readVector3f(buffer));
         itemTransaction.setClickPosition(helper.readVector3f(buffer));
         itemTransaction.setBlockDefinition(helper.getBlockDefinitions().getDefinition(VarInts.readUnsignedInt(buffer)));
-        itemTransaction.setClientInteractPrediction(ItemUseTransaction.PredictedResult.values()[VarInts.readUnsignedInt(buffer)]);
+        itemTransaction.setClientInteractPrediction(ItemUseTransaction.PredictedResult.values()[buffer.readByte()]);
         return itemTransaction;
     }
 }


### PR DESCRIPTION
Source: https://mojang.github.io/bedrock-protocol-docs/html/PackedItemUseLegacyInventoryTransaction.html

Client Interaction Prediction -> byte