### PR TITLE
Add fastutil bom to bedrock codec

### DIFF
--- a/bedrock-codec/build.gradle.kts
+++ b/bedrock-codec/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     api(projects.common)
+    api(platform(libs.fastutil.bom))
     api(libs.netty.buffer)
     api(libs.fastutil.long.common)
     api(libs.fastutil.long.`object`.maps)


### PR DESCRIPTION
This is required because the bedrock-codec project also has fast util dependencies and the BOM isn't transitively imported by the common project.