### PR TITLE
Fix LegacyTelemetryEventPacket

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/EventSerializer_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/EventSerializer_v291.java
@@ -103,7 +103,7 @@ public class EventSerializer_v291 implements BedrockPacketSerializer<EventPacket
         int interactionEntityType = VarInts.readInt(buffer);
         int entityVariant = VarInts.readInt(buffer);
         int entityColor = buffer.readUnsignedByte();
-        return new EntityInteractEventData(interactionType, interactionEntityType, entityVariant, entityColor);
+        return new EntityInteractEventData(-1L, interactionType, interactionEntityType, entityVariant, entityColor);
     }
 
     protected void writeEntityInteract(ByteBuf buffer, BedrockCodecHelper helper, EventData eventData) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v471/serializer/EventSerializer_v471.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v471/serializer/EventSerializer_v471.java
@@ -22,6 +22,8 @@ public class EventSerializer_v471 extends EventSerializer_v389 {
         this.writers.put(EventDataType.COPPER_WAXED_OR_UNWAXED, this::writeCopperWaxedUnwaxed);
         this.readers.put(EventDataType.CODE_BUILDER_ACTION, this::readCodeBuilderAction);
         this.writers.put(EventDataType.CODE_BUILDER_ACTION, this::writeCodeBuilderAction);
+        this.readers.put(EventDataType.CODE_BUILDER_SCOREBOARD, this::readCodeBuilderScoreboard);
+        this.writers.put(EventDataType.CODE_BUILDER_SCOREBOARD, this::writeCodeBuilderScoreboard);
         this.readers.put(EventDataType.STRIDER_RIDDEN_IN_LAVA_IN_OVERWORLD, (b, h) -> StriderRiddenInLavaInOverworldEventData.INSTANCE);
         this.writers.put(EventDataType.STRIDER_RIDDEN_IN_LAVA_IN_OVERWORLD, (b, h, e) -> {});
         this.readers.put(EventDataType.SNEAK_CLOSE_TO_SCULK_SENSOR, (b, h) -> SneakCloseToSculkSensorEventData.INSTANCE);

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v671/Bedrock_v671.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v671/Bedrock_v671.java
@@ -67,6 +67,7 @@ public class Bedrock_v671 extends Bedrock_v662 {
             .updateSerializer(UpdatePlayerGameTypePacket.class, UpdatePlayerGameTypeSerializer_v671.INSTANCE)
             .updateSerializer(StartGamePacket.class, StartGameSerializer_v671.INSTANCE)
             .updateSerializer(CraftingDataPacket.class, CraftingDataSerializer_v671.INSTANCE)
+            .updateSerializer(EventPacket.class, EventSerializer_v671.INSTANCE)
             .deregisterPacket(FilterTextPacket.class) // TODO: check
             // TODO: confirm change in AnimatePacket
             .build();

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v671/Bedrock_v671.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v671/Bedrock_v671.java
@@ -68,7 +68,6 @@ public class Bedrock_v671 extends Bedrock_v662 {
             .updateSerializer(StartGamePacket.class, StartGameSerializer_v671.INSTANCE)
             .updateSerializer(CraftingDataPacket.class, CraftingDataSerializer_v671.INSTANCE)
             .updateSerializer(EventPacket.class, EventSerializer_v671.INSTANCE)
-            .deregisterPacket(FilterTextPacket.class) // TODO: check
-            // TODO: confirm change in AnimatePacket
+            .deregisterPacket(FilterTextPacket.class)
             .build();
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v671/serializer/EventSerializer_v671.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v671/serializer/EventSerializer_v671.java
@@ -1,0 +1,32 @@
+package org.cloudburstmc.protocol.bedrock.codec.v671.serializer;
+
+import io.netty.buffer.ByteBuf;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
+import org.cloudburstmc.protocol.bedrock.codec.v589.serializer.EventSerializer_v589;
+import org.cloudburstmc.protocol.bedrock.data.event.EntityInteractEventData;
+import org.cloudburstmc.protocol.bedrock.data.event.EventData;
+import org.cloudburstmc.protocol.common.util.VarInts;
+
+public class EventSerializer_v671 extends EventSerializer_v589 {
+    public static final EventSerializer_v671 INSTANCE = new EventSerializer_v671();
+
+    @Override
+    protected EntityInteractEventData readEntityInteract(ByteBuf buffer, BedrockCodecHelper helper) {
+        long interactedEntityID = VarInts.readLong(buffer);
+        int interactionType = VarInts.readInt(buffer);
+        int interactionEntityType = VarInts.readInt(buffer);
+        int entityVariant = VarInts.readInt(buffer);
+        int entityColor = buffer.readUnsignedByte();
+        return new EntityInteractEventData(interactedEntityID, interactionType, interactionEntityType, entityVariant, entityColor);
+    }
+
+    @Override
+    protected void writeEntityInteract(ByteBuf buffer, BedrockCodecHelper helper, EventData eventData) {
+        EntityInteractEventData event = (EntityInteractEventData) eventData;
+        VarInts.writeLong(buffer, event.getInteractedEntityID());
+        VarInts.writeInt(buffer, event.getInteractionType());
+        VarInts.writeInt(buffer, event.getLegacyEntityTypeId());
+        VarInts.writeInt(buffer, event.getVariant());
+        buffer.writeByte(event.getPaletteColor());
+    }
+}

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v685/serializer/EventSerializer_v685.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v685/serializer/EventSerializer_v685.java
@@ -2,12 +2,12 @@ package org.cloudburstmc.protocol.bedrock.codec.v685.serializer;
 
 import io.netty.buffer.ByteBuf;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
-import org.cloudburstmc.protocol.bedrock.codec.v589.serializer.EventSerializer_v589;
+import org.cloudburstmc.protocol.bedrock.codec.v671.serializer.EventSerializer_v671;
 import org.cloudburstmc.protocol.bedrock.data.event.EventData;
 import org.cloudburstmc.protocol.bedrock.data.event.EventDataType;
 import org.cloudburstmc.protocol.bedrock.data.event.ItemUsedEventData;
 
-public class EventSerializer_v685 extends EventSerializer_v589 {
+public class EventSerializer_v685 extends EventSerializer_v671 {
     public static final EventSerializer_v685 INSTANCE = new EventSerializer_v685();
 
     public EventSerializer_v685() {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/event/EntityInteractEventData.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/event/EntityInteractEventData.java
@@ -4,6 +4,10 @@ import lombok.Value;
 
 @Value
 public class EntityInteractEventData implements EventData {
+    /**
+     * @since v671
+     */
+    private final long interactedEntityID;
     private final int interactionType;
     private final int legacyEntityTypeId;
     private final int variant;


### PR DESCRIPTION
It was probably forgotten to register the code builder scoreboard event data in the past as it still exists in the protocol docs. Also, this pull requests adds the missing interactedEntityID field to the entity interact event data of the LegacyTelemetryEventPacket.