### PR TITLE
Use AttributeKey#valueOf instead of AttributeKey#newInstance for PacketDirection attribute key

### DIFF
--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/PacketDirection.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/PacketDirection.java
@@ -15,7 +15,7 @@ public enum PacketDirection {
      */
     SERVER_BOUND(PacketRecipient.CLIENT, PacketRecipient.SERVER);
 
-    public static final AttributeKey<PacketDirection> ATTRIBUTE = AttributeKey.newInstance("packet_direction");
+    public static final AttributeKey<PacketDirection> ATTRIBUTE = AttributeKey.valueOf("packet_direction");
 
     private final PacketRecipient inbound;
     private final PacketRecipient outbound;


### PR DESCRIPTION
Uses AttributeKey#valueOf instead of AttributeKey#newInstance to not throw if the attribute was already created.

Example error occasionally seen in Geyser when users reload:
```
ja.lang.NoClassDefFoundError: Could not initialize class org.cloudburstmc.protocol.bedrock.PacketDirection
	at Geyser-Spigot.jar/org.cloudburstmc.protocol.bedrock.netty.initializer.BedrockServerInitializer.preInitChannel(BedrockServerInitializer.java:12) ~[Geyser-Spigot.jar:?]
	at Geyser-Spigot.jar/org.cloudburstmc.protocol.bedrock.netty.initializer.BedrockChannelInitializer.initChannel(BedrockChannelInitializer.java:33) ~[Geyser-Spigot.jar:?]
	at io.netty.channel.ChannelInitializer.initChannel(ChannelInitializer.java:129) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.ChannelInitializer.handlerAdded(ChannelInitializer.java:112) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannelHandlerContext.callHandlerAdded(AbstractChannelHandlerContext.java:1114) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultChannelPipeline.callHandlerAdded0(DefaultChannelPipeline.java:609) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultChannelPipeline.access$100(DefaultChannelPipeline.java:46) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultChannelPipeline$PendingHandlerAddedTask.execute(DefaultChannelPipeline.java:1463) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultChannelPipeline.callHandlerAddedForAllHandlers(DefaultChannelPipeline.java:1115) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.DefaultChannelPipeline.invokeHandlerAddedIfNeeded(DefaultChannelPipeline.java:650) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.register0(AbstractChannel.java:514) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe.access$200(AbstractChannel.java:429) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.AbstractChannel$AbstractUnsafe$1.run(AbstractChannel.java:486) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.runTask(AbstractEventExecutor.java:174) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:167) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:470) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:569) ~[netty-transport-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.IllegalArgumentException: 'packet_direction' is already in use [in thread "nioEventLoopGroup-10-1"]
	at io.netty.util.ConstantPool.createOrThrow(ConstantPool.java:108) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.ConstantPool.newInstance(ConstantPool.java:90) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at io.netty.util.AttributeKey.newInstance(AttributeKey.java:55) ~[netty-common-4.1.97.Final.jar:4.1.97.Final]
	at Geyser-Spigot.jar/org.cloudburstmc.protocol.bedrock.PacketDirection.<clinit>(PacketDirection.java:18) ~[Geyser-Spigot.jar:?]
	... 21 more
```

Comparison of valueOf vs newInstance:
![image](https://github.com/user-attachments/assets/7ba7a346-6cee-4435-a033-22fcf5933be6)
![image](https://github.com/user-attachments/assets/f9f5115e-cf8a-40fc-9b34-b205a2fe32db)
