### PR TITLE
Set animations to empty list if null in SerializedSkin.Builder

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/SerializedSkin.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/SerializedSkin.java
@@ -305,6 +305,7 @@ public class SerializedSkin {
 
         public SerializedSkin build() {
             if (playFabId == null) playFabId = "";
+            if (animations == null) animations = Collections.emptyList();
             if (animationData == null) animationData = "";
             if (capeData == null) capeData = ImageData.EMPTY;
             if (capeId == null) capeId = "";


### PR DESCRIPTION
When `builder.animations(...)` is not called, it causes `builder.build()` to fail with the following stack trace. This PR fixes the issue by initializing the animations to empty list just like what's being done with `personaPieces` and `tintColors` 

```
Caused by: java.lang.NullPointerException: Cannot invoke "java.util.Collection.size()" because "c" is null
	at it.unimi.dsi.fastutil.objects.ObjectArrayList.<init>(ObjectArrayList.java:135) ~[lux.jar:?]
	at org.cloudburstmc.protocol.bedrock.data.skin.SerializedSkin.of(SerializedSkin.java:101) ~[lux.jar:?]
	at org.cloudburstmc.protocol.bedrock.data.skin.SerializedSkin$Builder.build(SerializedSkin.java:322) ~[lux.jar:?]
```