### PR TITLE
Add SimpleNamedDefinition

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/definitions/SimpleNamedDefinition.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/definitions/SimpleNamedDefinition.java
@@ -1,0 +1,10 @@
+package org.cloudburstmc.protocol.bedrock.data.definitions;
+
+import lombok.Value;
+import org.cloudburstmc.protocol.common.NamedDefinition;
+
+@Value
+public class SimpleNamedDefinition implements NamedDefinition {
+    String identifier;
+    int runtimeId;
+}


### PR DESCRIPTION
For the other `DefinitionRegistry` instances other than the camera preset registry, they have classes for their definition equivalent interface. (e.g. `SimpleBlockDefinition` exists and implements `BlockDefinition`)

The problem is that for camera presets, there is no implementation of **just** the `NamedDefinition` interface. For consistency as well as to help ProxyPass support deserializing/serializing camera related packets, this class just serves as a basic implementation for `NamedDefinition`.

I chose to implement it here rather than in `ProxyPass` for consistency with the other definition classes and also it might come in handy in the future.