### PR TITLE
1.21.50 is protocol version 766, not 765

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Check out [EXAMPLES.md](EXAMPLES.md) for examples on how to use this library.
 | Bedrock_v712 |       1.21.20       |
 | Bedrock_v729 |       1.21.30       |
 | Bedrock_v748 |       1.21.40       |
+| Bedrock_v766 |       1.21.50       |
 
 ##### Repository:
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/BedrockCodecHelper_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/BedrockCodecHelper_v766.java
@@ -1,4 +1,4 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765;
+package org.cloudburstmc.protocol.bedrock.codec.v766;
 
 import io.netty.buffer.ByteBuf;
 import org.cloudburstmc.protocol.bedrock.codec.EntityDataTypeMap;
@@ -15,9 +15,9 @@ import java.math.BigInteger;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
-public class BedrockCodecHelper_v765 extends BedrockCodecHelper_v729 {
+public class BedrockCodecHelper_v766 extends BedrockCodecHelper_v729 {
 
-    public BedrockCodecHelper_v765(EntityDataTypeMap entityData, TypeMap<Class<?>> gameRulesTypes, TypeMap<ItemStackRequestActionType> stackRequestActionTypes,
+    public BedrockCodecHelper_v766(EntityDataTypeMap entityData, TypeMap<Class<?>> gameRulesTypes, TypeMap<ItemStackRequestActionType> stackRequestActionTypes,
                                    TypeMap<ContainerSlotType> containerSlotTypes, TypeMap<Ability> abilities, TypeMap<TextProcessingEventOrigin> textProcessingEventOrigins) {
         super(entityData, gameRulesTypes, stackRequestActionTypes, containerSlotTypes, abilities, textProcessingEventOrigins);
     }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/Bedrock_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/Bedrock_v766.java
@@ -1,4 +1,4 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765;
+package org.cloudburstmc.protocol.bedrock.codec.v766;
 
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
 import org.cloudburstmc.protocol.bedrock.codec.v291.serializer.LevelEventSerializer_v291;
@@ -7,12 +7,12 @@ import org.cloudburstmc.protocol.bedrock.codec.v313.serializer.LevelSoundEvent2S
 import org.cloudburstmc.protocol.bedrock.codec.v332.serializer.LevelSoundEventSerializer_v332;
 import org.cloudburstmc.protocol.bedrock.codec.v361.serializer.LevelEventGenericSerializer_v361;
 import org.cloudburstmc.protocol.bedrock.codec.v748.Bedrock_v748;
-import org.cloudburstmc.protocol.bedrock.codec.v765.serializer.*;
+import org.cloudburstmc.protocol.bedrock.codec.v766.serializer.*;
 import org.cloudburstmc.protocol.bedrock.data.*;
 import org.cloudburstmc.protocol.bedrock.packet.*;
 import org.cloudburstmc.protocol.common.util.TypeMap;
 
-public class Bedrock_v765 extends Bedrock_v748 {
+public class Bedrock_v766 extends Bedrock_v748 {
 
     protected static final TypeMap<SoundEvent> SOUND_EVENTS = Bedrock_v748.SOUND_EVENTS
             .toBuilder()
@@ -45,18 +45,18 @@ public class Bedrock_v765 extends Bedrock_v748 {
 
     public static final BedrockCodec CODEC = Bedrock_v748.CODEC.toBuilder()
             .raknetProtocolVersion(11)
-            .protocolVersion(765)
+            .protocolVersion(766)
             .minecraftVersion("1.21.50")
-            .helper(() -> new BedrockCodecHelper_v765(ENTITY_DATA, GAME_RULE_TYPES, ITEM_STACK_REQUEST_TYPES, CONTAINER_SLOT_TYPES, PLAYER_ABILITIES, TEXT_PROCESSING_ORIGINS))
+            .helper(() -> new BedrockCodecHelper_v766(ENTITY_DATA, GAME_RULE_TYPES, ITEM_STACK_REQUEST_TYPES, CONTAINER_SLOT_TYPES, PLAYER_ABILITIES, TEXT_PROCESSING_ORIGINS))
             .updateSerializer(LevelEventPacket.class, new LevelEventSerializer_v291(LEVEL_EVENTS))
             .updateSerializer(LevelEventGenericPacket.class, new LevelEventGenericSerializer_v361(LEVEL_EVENTS))
             .updateSerializer(LevelSoundEvent1Packet.class, new LevelSoundEvent1Serializer_v291(SOUND_EVENTS))
             .updateSerializer(LevelSoundEvent2Packet.class, new LevelSoundEvent2Serializer_v313(SOUND_EVENTS))
             .updateSerializer(LevelSoundEventPacket.class, new LevelSoundEventSerializer_v332(SOUND_EVENTS))
-            .updateSerializer(CameraAimAssistPacket.class, CameraAimAssistSerializer_v765.INSTANCE)
-            .updateSerializer(ResourcePacksInfoPacket.class, ResourcePacksInfoSerializer_v765.INSTANCE)
-            .updateSerializer(PlayerAuthInputPacket.class, PlayerAuthInputSerializer_v765.INSTANCE)
-            .updateSerializer(CameraPresetsPacket.class, CameraPresetsSerializer_v765.INSTANCE)
-            .registerPacket(CameraAimAssistPresetsPacket::new, CameraAimAssistPresetsSerializer_v765.INSTANCE, 320, PacketRecipient.CLIENT)
+            .updateSerializer(CameraAimAssistPacket.class, CameraAimAssistSerializer_v766.INSTANCE)
+            .updateSerializer(ResourcePacksInfoPacket.class, ResourcePacksInfoSerializer_v766.INSTANCE)
+            .updateSerializer(PlayerAuthInputPacket.class, PlayerAuthInputSerializer_v766.INSTANCE)
+            .updateSerializer(CameraPresetsPacket.class, CameraPresetsSerializer_v766.INSTANCE)
+            .registerPacket(CameraAimAssistPresetsPacket::new, CameraAimAssistPresetsSerializer_v766.INSTANCE, 320, PacketRecipient.CLIENT)
             .build();
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/CameraAimAssistPresetsSerializer_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/CameraAimAssistPresetsSerializer_v766.java
@@ -1,4 +1,4 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765.serializer;
+package org.cloudburstmc.protocol.bedrock.codec.v766.serializer;
 
 import io.netty.buffer.ByteBuf;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
@@ -6,8 +6,8 @@ import org.cloudburstmc.protocol.bedrock.codec.BedrockPacketSerializer;
 import org.cloudburstmc.protocol.bedrock.data.camera.*;
 import org.cloudburstmc.protocol.bedrock.packet.CameraAimAssistPresetsPacket;
 
-public class CameraAimAssistPresetsSerializer_v765 implements BedrockPacketSerializer<CameraAimAssistPresetsPacket> {
-    public static final CameraAimAssistPresetsSerializer_v765 INSTANCE = new CameraAimAssistPresetsSerializer_v765();
+public class CameraAimAssistPresetsSerializer_v766 implements BedrockPacketSerializer<CameraAimAssistPresetsPacket> {
+    public static final CameraAimAssistPresetsSerializer_v766 INSTANCE = new CameraAimAssistPresetsSerializer_v766();
 
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, CameraAimAssistPresetsPacket packet) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/CameraAimAssistSerializer_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/CameraAimAssistSerializer_v766.java
@@ -1,12 +1,12 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765.serializer;
+package org.cloudburstmc.protocol.bedrock.codec.v766.serializer;
 
 import io.netty.buffer.ByteBuf;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
 import org.cloudburstmc.protocol.bedrock.codec.v729.serializer.CameraAimAssistSerializer_v729;
 import org.cloudburstmc.protocol.bedrock.packet.CameraAimAssistPacket;
 
-public class CameraAimAssistSerializer_v765 extends CameraAimAssistSerializer_v729 {
-    public static final CameraAimAssistSerializer_v765 INSTANCE = new CameraAimAssistSerializer_v765();
+public class CameraAimAssistSerializer_v766 extends CameraAimAssistSerializer_v729 {
+    public static final CameraAimAssistSerializer_v766 INSTANCE = new CameraAimAssistSerializer_v766();
 
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, CameraAimAssistPacket packet) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/CameraPresetsSerializer_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/CameraPresetsSerializer_v766.java
@@ -1,4 +1,4 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765.serializer;
+package org.cloudburstmc.protocol.bedrock.codec.v766.serializer;
 
 import io.netty.buffer.ByteBuf;
 import lombok.AccessLevel;
@@ -13,8 +13,8 @@ import org.cloudburstmc.protocol.bedrock.data.camera.CameraPreset;
 import org.cloudburstmc.protocol.common.util.OptionalBoolean;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class CameraPresetsSerializer_v765 extends CameraPresetsSerializer_v729 {
-    public static final CameraPresetsSerializer_v765 INSTANCE = new CameraPresetsSerializer_v765();
+public class CameraPresetsSerializer_v766 extends CameraPresetsSerializer_v729 {
+    public static final CameraPresetsSerializer_v766 INSTANCE = new CameraPresetsSerializer_v766();
 
     @Override
     public void writePreset(ByteBuf buffer, BedrockCodecHelper helper, CameraPreset preset) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/PlayerAuthInputSerializer_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/PlayerAuthInputSerializer_v766.java
@@ -1,4 +1,4 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765.serializer;
+package org.cloudburstmc.protocol.bedrock.codec.v766.serializer;
 
 import io.netty.buffer.ByteBuf;
 import lombok.AccessLevel;
@@ -13,9 +13,9 @@ import org.cloudburstmc.protocol.bedrock.packet.PlayerAuthInputPacket;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class PlayerAuthInputSerializer_v765 extends PlayerAuthInputSerializer_v748 {
+public class PlayerAuthInputSerializer_v766 extends PlayerAuthInputSerializer_v748 {
 
-    public static final PlayerAuthInputSerializer_v765 INSTANCE = new PlayerAuthInputSerializer_v765();
+    public static final PlayerAuthInputSerializer_v766 INSTANCE = new PlayerAuthInputSerializer_v766();
 
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, PlayerAuthInputPacket packet) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/ResourcePacksInfoSerializer_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/serializer/ResourcePacksInfoSerializer_v766.java
@@ -1,4 +1,4 @@
-package org.cloudburstmc.protocol.bedrock.codec.v765.serializer;
+package org.cloudburstmc.protocol.bedrock.codec.v766.serializer;
 
 import io.netty.buffer.ByteBuf;
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
@@ -8,8 +8,8 @@ import org.cloudburstmc.protocol.bedrock.packet.ResourcePacksInfoPacket;
 import java.util.Objects;
 import java.util.UUID;
 
-public class ResourcePacksInfoSerializer_v765 extends ResourcePacksInfoSerializer_v748 {
-    public static final ResourcePacksInfoSerializer_v765 INSTANCE = new ResourcePacksInfoSerializer_v765();
+public class ResourcePacksInfoSerializer_v766 extends ResourcePacksInfoSerializer_v748 {
+    public static final ResourcePacksInfoSerializer_v766 INSTANCE = new ResourcePacksInfoSerializer_v766();
 
     @Override
     public void serialize(ByteBuf buffer, BedrockCodecHelper helper, ResourcePacksInfoPacket packet) {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/LevelEvent.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/LevelEvent.java
@@ -112,7 +112,7 @@ public enum LevelEvent implements LevelEventType {
     PARTICLE_TRIAL_SPAWNER_BECOME_CHARGED,
     PARTICLE_SMASH_ATTACK_GROUND_DUST,
     /**
-     * @since v765
+     * @since v766
      */
     PARTICLE_CREAKING_HEART_TRIAL,
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/ParticleType.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/ParticleType.java
@@ -123,19 +123,19 @@ public enum ParticleType implements LevelEventType {
      */
     OMINOUS_ITEM_SPAWNER,
     /**
-     * @since 765
+     * @since 766
      */
     CREAKING_CRUMBLE,
     /**
-     * @since 765
+     * @since 766
      */
     PALE_OAK_LEAVES,
     /**
-     * @since 765
+     * @since 766
      */
     EYEBLOSSOM_OPEN,
     /**
-     * @since 765
+     * @since 766
      */
     EYEBLOSSOM_CLOSE,
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/PlayerAuthInputData.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/PlayerAuthInputData.java
@@ -126,27 +126,27 @@ public enum PlayerAuthInputData {
      */
     STOP_SPIN_ATTACK,
     /**
-     * @since v765
+     * @since v766
      */
     JUMP_RELEASED_RAW,
     /**
-     * @since v765
+     * @since v766
      */
     JUMP_PRESSED_RAW,
     /**
-     * @since v765
+     * @since v766
      */
     JUMP_CURRENT_RAW,
     /**
-     * @since v765
+     * @since v766
      */
     SNEAK_RELEASED_RAW,
     /**
-     * @since v765
+     * @since v766
      */
     SNEAK_PRESSED_RAW,
     /**
-     * @since v765
+     * @since v766
      */
     SNEAK_CURRENT_RAW,
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/SoundEvent.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/SoundEvent.java
@@ -751,51 +751,51 @@ public enum SoundEvent {
      */
     BUNDLE_INSERT_FAILED,
     /**
-     * @since v765
+     * @since v766
      */
     IMITATE_CREAKING,
     /**
-     * @since v765
+     * @since v766
      */
     SPONGE_ABSORB,
     /**
-     * @since v765
+     * @since v766
      */
     BLOCK_CREAKING_HEART_TRAIL,
     /**
-     * @since v765
+     * @since v766
      */
     CREAKING_HEART_SPAWN,
     /**
-     * @since v765
+     * @since v766
      */
     ACTIVATE,
     /**
-     * @since v765
+     * @since v766
      */
     DEACTIVATE,
     /**
-     * @since v765
+     * @since v766
      */
     FREEZE,
     /**
-     * @since v765
+     * @since v766
      */
     UNFREEZE,
     /**
-     * @since v765
+     * @since v766
      */
     OPEN,
     /**
-     * @since v765
+     * @since v766
      */
     OPEN_LONG,
     /**
-     * @since v765
+     * @since v766
      */
     CLOSE,
     /**
-     * @since v765
+     * @since v766
      */
     CLOSE_LONG,
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/camera/CameraPreset.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/camera/CameraPreset.java
@@ -63,11 +63,11 @@ public class CameraPreset {
     @Builder.Default
     private OptionalBoolean alignTargetAndCameraForward = OptionalBoolean.empty();
     /**
-     * @since v765
+     * @since v766
      */
     private Float blockListeningRadius;
     /**
-     * @since v765
+     * @since v766
      */
     private CameraAimAssistPreset aimAssistPreset;
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/inventory/itemstack/response/ItemStackResponseSlot.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/inventory/itemstack/response/ItemStackResponseSlot.java
@@ -30,7 +30,7 @@ public class ItemStackResponseSlot {
      */
     private int durabilityCorrection;
     /**
-     * @since v765
+     * @since v766
      */
     private String filteredCustomName = "";
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/CameraAimAssistPacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/CameraAimAssistPacket.java
@@ -15,7 +15,7 @@ public class CameraAimAssistPacket implements BedrockPacket {
     private TargetMode targetMode;
     private Action action;
     /**
-     * @since v765
+     * @since v766
      */
     private String presetId;
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/PlayerAuthInputPacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/PlayerAuthInputPacket.java
@@ -74,7 +74,7 @@ public class PlayerAuthInputPacket implements BedrockPacket {
      */
     private Vector3f cameraOrientation;
     /**
-     * @since v765
+     * @since v766
      */
     private Vector2f rawMoveVector;
 

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/ResourcePacksInfoPacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/ResourcePacksInfoPacket.java
@@ -28,11 +28,11 @@ public class ResourcePacksInfoPacket implements BedrockPacket {
      */
     private boolean forcingServerPacksEnabled;
     /**
-     * @since v765
+     * @since v766
      */
     private UUID worldTemplateId;
     /**
-     * @since v765
+     * @since v766
      */
     private String worldTemplateVersion;
 


### PR DESCRIPTION
Discovered when attempting to connect with the 1.21.50.29 preview client. According to the [protocol docs](https://github.com/Mojang/bedrock-protocol-docs/pull/16) and the protocol version sent by the preview client, 1.21.50 uses the protocol version 766 instead of 765.