### PR TITLE
1.21.50 fixes

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/BedrockCodecHelper_v766.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v766/BedrockCodecHelper_v766.java
@@ -34,7 +34,7 @@ public class BedrockCodecHelper_v766 extends BedrockCodecHelper_v729 {
 
     @Override
     public <T extends Enum<?>> void writeLargeVarIntFlags(ByteBuf buffer, Set<T> flags, Class<T> clazz) {
-        BigInteger flagsInt = new BigInteger(clazz.getEnumConstants().length, ThreadLocalRandom.current());
+        BigInteger flagsInt = BigInteger.ZERO;
         for (T flag : flags) {
             flagsInt = flagsInt.setBit(flag.ordinal());
         }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/PlayerAuthInputData.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/PlayerAuthInputData.java
@@ -128,6 +128,10 @@ public enum PlayerAuthInputData {
     /**
      * @since v766
      */
+    HOTBAR_ONLY_TOUCH,
+    /**
+     * @since v766
+     */
     JUMP_RELEASED_RAW,
     /**
      * @since v766


### PR DESCRIPTION
this took me many hours of confusion

when you write the VarInt you're supposed to assume it's zeroed out. otherwise a ton of other enum values will be written in
and then an additional auth input data