### PR TITLE
fix: AdventureSettingsPacket can be both server- and clientbound

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/Bedrock_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/Bedrock_v291.java
@@ -687,7 +687,7 @@ public class Bedrock_v291 {
             .registerPacket(CraftingDataPacket::new, CraftingDataSerializer_v291.INSTANCE, 52, PacketRecipient.CLIENT)
             .registerPacket(CraftingEventPacket::new, CraftingEventSerializer_v291.INSTANCE, 53, PacketRecipient.BOTH)
             .registerPacket(GuiDataPickItemPacket::new, GuiDataPickItemSerializer_v291.INSTANCE, 54, PacketRecipient.CLIENT)
-            .registerPacket(AdventureSettingsPacket::new, AdventureSettingsSerializer_v291.INSTANCE, 55, PacketRecipient.CLIENT)
+            .registerPacket(AdventureSettingsPacket::new, AdventureSettingsSerializer_v291.INSTANCE, 55, PacketRecipient.BOTH)
             .registerPacket(BlockEntityDataPacket::new, BlockEntityDataSerializer_v291.INSTANCE, 56, PacketRecipient.BOTH)
             .registerPacket(PlayerInputPacket::new, PlayerInputSerializer_v291.INSTANCE, 57, PacketRecipient.SERVER)
             .registerPacket(LevelChunkPacket::new, FullChunkDataSerializer_v291.INSTANCE, 58, PacketRecipient.CLIENT)


### PR DESCRIPTION
this is true for older versions of MCBE in cases of using flight, for example