### PR TITLE
Correctly set named groups when jdk.tls.namedGroups is set

### DIFF
--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
@@ -43,7 +43,7 @@ public class EncryptionUtils {
         // DO NOT REMOVE THIS
         // Since Java 8u231, secp384r1 is deprecated and will throw an exception.
         String namedGroups = System.getProperty("jdk.tls.namedGroups");
-        System.setProperty("jdk.tls.namedGroups", namedGroups == null || namedGroups.isEmpty() ? "secp384r1" : ", secp384r1");
+        System.setProperty("jdk.tls.namedGroups", namedGroups == null || namedGroups.isEmpty() ? "secp384r1" : namedGroups + ", secp384r1");
 
         try {
             KEY_PAIR_GEN = KeyPairGenerator.getInstance("EC");


### PR DESCRIPTION
The original named groups are now concatenated if jdk.tls.namedGroups is previously set.

I feel like an uninformed user would not know to set jdk.tls.namedGroups in the first place, and only using secp384r1 might be an issue when making HTTPS requests to certain websites. Maybe it should set some other named groups by default as well?