### PR TITLE
fix: revert petteri's changes for AvailableCommandsSerializer_v594

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v594/serializer/AvailableCommandsSerializer_v594.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v594/serializer/AvailableCommandsSerializer_v594.java
@@ -49,11 +49,11 @@ public class AvailableCommandsSerializer_v594 extends AvailableCommandsSerialize
 
                 subCommandData.add(subcommand);
                 for (ChainedSubCommandData.Value value : subcommand.getValues()) {
-                    if (!subCommandValues.contains(value.getFirst())) {
+                    if (subCommandValues.contains(value.getFirst())) {
                         subCommandValues.add(value.getFirst());
                     }
 
-                    if (!subCommandValues.contains(value.getSecond())) {
+                    if (subCommandValues.contains(value.getSecond())) {
                         subCommandValues.add(value.getSecond());
                     }
                 }


### PR DESCRIPTION
Revert change c0569eeb8b13f1caa5d24fbdaaa3e6aa006cc039, because it breaks the serialization of AvailableCommandsPacket. 
Example: WaterdogPE using Cloudburst Protocol 3.0.0.Beta7-SNAPSHOT. Log attached.

[server.log](https://github.com/user-attachments/files/20813524/server.log)
