### PR TITLE
Fix xuid key name for the new identity claims

### DIFF
--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/ChainValidationResult.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/ChainValidationResult.java
@@ -90,7 +90,7 @@ public final class ChainValidationResult {
 
         String identityPublicKey = claims.getClaimValueAsString("cpk");
         String displayName = claims.getClaimValueAsString("xname");
-        String xuid = claims.getClaimValueAsString("xuid");
+        String xuid = claims.getClaimValueAsString("xid");
         String minecraftId = claims.getClaimValueAsString("mid");
         UUID identity = UUID.nameUUIDFromBytes(xuid.getBytes(StandardCharsets.UTF_8));
 


### PR DESCRIPTION
New identity claims data contains the XUID as key "xid"