### PR TITLE
Prefix the xuid to derive the correct identity

### DIFF
--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/ChainValidationResult.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/ChainValidationResult.java
@@ -92,7 +92,7 @@ public final class ChainValidationResult {
         String displayName = claims.getClaimValueAsString("xname");
         String xuid = claims.getClaimValueAsString("xid");
         String minecraftId = claims.getClaimValueAsString("mid");
-        UUID identity = UUID.nameUUIDFromBytes(xuid.getBytes(StandardCharsets.UTF_8));
+        UUID identity = UUID.nameUUIDFromBytes(("pocket-auth-1-xuid:" + xuid).getBytes(StandardCharsets.UTF_8));
 
         return new IdentityClaims(
                 new IdentityData(displayName, identity, xuid, null, minecraftId),

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
@@ -74,6 +74,7 @@ public class EncryptionUtils {
 
     private static final JwtConsumer OFFLINE_CONSUMER = new JwtConsumerBuilder()
             .setSkipAllValidators()
+            .setSkipSignatureVerification()
             .setRequireExpirationTime()
             .setSkipDefaultAudienceValidation()
             .build();


### PR DESCRIPTION
Prefixed xuid with "pocket-auth-1-xuid:" to derive the correct UUID.
Added setSkipSignatureVerification for OFFLINE_CONSUMER.
