### PR TITLE
Fix EntityDataMap serialization to only write present flag groups

### DIFF
--- a/adventure/src/test/java/org/cloudburstmc/protocol/bedrock/test/TextSerializationTest.java
+++ b/adventure/src/test/java/org/cloudburstmc/protocol/bedrock/test/TextSerializationTest.java
@@ -20,6 +20,7 @@ import org.cloudburstmc.protocol.bedrock.codec.v776.Bedrock_v776;
 import org.cloudburstmc.protocol.bedrock.data.Ability;
 import org.cloudburstmc.protocol.bedrock.data.AbilityLayer;
 import org.cloudburstmc.protocol.bedrock.data.GameType;
+import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataMap;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
@@ -27,10 +28,7 @@ import org.cloudburstmc.protocol.bedrock.packet.AddPlayerPacket;
 import org.cloudburstmc.protocol.bedrock.packet.TextPacket;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -192,7 +190,7 @@ public class TextSerializationTest {
         packet.getMetadata().put(EntityDataTypes.HEIGHT, 0.6f);
         packet.getMetadata().put(EntityDataTypes.NAMETAG_ALWAYS_SHOW, (byte) 0);
 
-        packet.getMetadata().putFlags(EnumSet.of(EntityFlag.SILENT));
+        packet.getMetadata().putFlags(EntityDataMap.flagsOf(EntityFlag.SILENT));
 
         ByteBuf buf = Unpooled.buffer();
         PLAYER_SERIALIZER.serialize(buf, CODEC_HELPER, packet);

--- a/bedrock-codec/build.gradle.kts
+++ b/bedrock-codec/build.gradle.kts
@@ -7,6 +7,9 @@ dependencies {
     api(libs.jose4j)
     api(libs.nbt)
     implementation(libs.jackson.annotations)
+
+    // Tests
+    testImplementation(libs.junit)
 }
 
 tasks.jar {

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/BedrockCodecHelper_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/BedrockCodecHelper_v291.java
@@ -17,10 +17,7 @@ import org.cloudburstmc.protocol.bedrock.data.command.CommandEnumData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandOriginData;
 import org.cloudburstmc.protocol.bedrock.data.command.CommandOriginType;
 import org.cloudburstmc.protocol.bedrock.data.definitions.ItemDefinition;
-import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataFormat;
-import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataMap;
-import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataType;
-import org.cloudburstmc.protocol.bedrock.data.entity.EntityLinkData;
+import org.cloudburstmc.protocol.bedrock.data.entity.*;
 import org.cloudburstmc.protocol.bedrock.data.inventory.ItemData;
 import org.cloudburstmc.protocol.bedrock.transformer.EntityDataTransformer;
 import org.cloudburstmc.protocol.common.util.TriConsumer;
@@ -236,7 +233,7 @@ public class BedrockCodecHelper_v291 extends BaseBedrockCodecHelper {
 
     @Override
     public void readEntityData(ByteBuf buffer, EntityDataMap entityDataMap) {
-        checkNotNull(entityDataMap, "entityDataDictionary");
+        checkNotNull(entityDataMap, "entityDataMap");
 
         int length = VarInts.readUnsignedInt(buffer);
         checkArgument(this.encodingSettings.maxListSize() <= 0 || length <= this.encodingSettings.maxListSize(), "Entity data size is too big: %s", length);
@@ -285,7 +282,7 @@ public class BedrockCodecHelper_v291 extends BaseBedrockCodecHelper {
                     EntityDataTransformer<Object, ?> transformer = (EntityDataTransformer<Object, ?>) definition.getTransformer();
                     Object transformedValue = transformer.deserialize(this, entityDataMap, value);
                     if (transformedValue != null) {
-                        entityDataMap.put(definition.getType(), transformer.deserialize(this, entityDataMap, value));
+                        entityDataMap.put(definition.getType(), transformedValue);
                     }
                 }
             } else {
@@ -297,58 +294,73 @@ public class BedrockCodecHelper_v291 extends BaseBedrockCodecHelper {
     @SuppressWarnings("unchecked")
     @Override
     public void writeEntityData(ByteBuf buffer, EntityDataMap entityDataMap) {
-        checkNotNull(entityDataMap, "entityDataDictionary");
+        checkNotNull(entityDataMap, "entityDataMap");
 
-        VarInts.writeUnsignedInt(buffer, entityDataMap.size());
+        // Collect serialized entries first
+        List<Map.Entry<EntityDataTypeMap.Definition<?>, Object>> serializedEntries = new LinkedList<>();
 
         for (Map.Entry<EntityDataType<?>, Object> entry : entityDataMap.entrySet()) {
             EntityDataTypeMap.Definition<?> definition = this.entityData.fromType(entry.getKey());
-
-            VarInts.writeUnsignedInt(buffer, definition.getId());
-            VarInts.writeUnsignedInt(buffer, definition.getFormat().ordinal());
 
             try {
                 Object value = ((EntityDataTransformer<?, Object>) definition.getTransformer())
                         .serialize(this, entityDataMap, entry.getValue());
 
-                switch (definition.getFormat()) {
-                    case BYTE:
-                        buffer.writeByte((byte) value);
-                        break;
-                    case SHORT:
-                        buffer.writeShortLE((short) value);
-                        break;
-                    case INT:
-                        VarInts.writeInt(buffer, (int) value);
-                        break;
-                    case FLOAT:
-                        buffer.writeFloatLE((float) value);
-                        break;
-                    case STRING:
-                        writeString(buffer, (String) value);
-                        break;
-                    case NBT:
-                        this.writeItem(buffer, ItemData.builder()
-                                .definition(ItemDefinition.LEGACY_FIREWORK)
-                                .damage(0)
-                                .count(1)
-                                .tag((NbtMap) value)
-                                .build());
-                        break;
-                    case VECTOR3I:
-                        writeVector3i(buffer, (Vector3i) value);
-                        break;
-                    case LONG:
-                        VarInts.writeLong(buffer, (long) value);
-                        break;
-                    case VECTOR3F:
-                        writeVector3f(buffer, (Vector3f) value);
-                        break;
-                    default:
-                        throw new UnsupportedOperationException("Unknown entity data type " + definition.getFormat());
+                // Skip if transformer returns null (indicating this entry shouldn't be serialized)
+                if (value == null) {
+                    continue;
                 }
+
+                serializedEntries.add(new AbstractMap.SimpleEntry<>(definition, value));
             } catch (Exception e) {
                 throw new IllegalArgumentException("Failed to encode EntityData " + definition.getId() + " of " + definition.getType().getTypeName(), e);
+            }
+        }
+
+        VarInts.writeUnsignedInt(buffer, serializedEntries.size());
+
+        for (Map.Entry<EntityDataTypeMap.Definition<?>, Object> entry : serializedEntries) {
+            EntityDataTypeMap.Definition<?> definition = entry.getKey();
+            Object value = entry.getValue();
+
+            VarInts.writeUnsignedInt(buffer, definition.getId());
+            VarInts.writeUnsignedInt(buffer, definition.getFormat().ordinal());
+
+            switch (definition.getFormat()) {
+                case BYTE:
+                    buffer.writeByte((byte) value);
+                    break;
+                case SHORT:
+                    buffer.writeShortLE((short) value);
+                    break;
+                case INT:
+                    VarInts.writeInt(buffer, (int) value);
+                    break;
+                case FLOAT:
+                    buffer.writeFloatLE((float) value);
+                    break;
+                case STRING:
+                    writeString(buffer, (String) value);
+                    break;
+                case NBT:
+                    this.writeItem(buffer, ItemData.builder()
+                            .definition(ItemDefinition.LEGACY_FIREWORK)
+                            .damage(0)
+                            .count(1)
+                            .tag((NbtMap) value)
+                            .build());
+                    break;
+                case VECTOR3I:
+                    writeVector3i(buffer, (Vector3i) value);
+                    break;
+                case LONG:
+                    VarInts.writeLong(buffer, (long) value);
+                    break;
+                case VECTOR3F:
+                    writeVector3f(buffer, (Vector3f) value);
+                    break;
+                default:
+                    throw new UnsupportedOperationException("Unknown entity data type " + definition.getFormat());
             }
         }
     }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/entity/EntityDataMap.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/entity/EntityDataMap.java
@@ -12,38 +12,48 @@ import static org.cloudburstmc.protocol.common.util.Preconditions.checkNotNull;
 
 public final class EntityDataMap implements Map<EntityDataType<?>, Object> {
 
+    public static EnumMap<EntityFlag, Boolean> flagsOf(EntityFlag... flags) {
+        EnumMap<EntityFlag, Boolean> map = new EnumMap<>(EntityFlag.class);
+        for (EntityFlag flag : flags) {
+            map.put(flag, true);
+        }
+        return map;
+    }
+
     private final Map<EntityDataType<?>, Object> map = new LinkedHashMap<>();
 
     @NonNull
-    public EnumSet<EntityFlag> getOrCreateFlags() {
-        EnumSet<EntityFlag> flags = get(FLAGS);
+    public EnumMap<EntityFlag, Boolean> getOrCreateFlags() {
+        EnumMap<EntityFlag, Boolean> flags = get(FLAGS);
         if (flags == null) {
             flags = get(FLAGS_2);
             if (flags == null) {
-                flags = EnumSet.noneOf(EntityFlag.class);
+                flags = new EnumMap<>(EntityFlag.class);
             }
             this.putFlags(flags);
         }
         return flags;
     }
 
-    public EnumSet<EntityFlag> getFlags() {
+    public EnumMap<EntityFlag, Boolean> getFlags() {
         return get(FLAGS);
+    }
+
+    public EntityFlag clearFlag(EntityFlag flag) {
+        Objects.requireNonNull(flag, "flag");
+        EnumMap<EntityFlag, Boolean> flags = this.getOrCreateFlags();
+        flags.remove(flag);
+        return flag;
     }
 
     public EntityFlag setFlag(EntityFlag flag, boolean value) {
         Objects.requireNonNull(flag, "flag");
-        EnumSet<EntityFlag> flags = this.getOrCreateFlags();
-        if (value) {
-            flags.add(flag);
-        } else {
-            flags.remove(flag);
-        }
-
+        EnumMap<EntityFlag, Boolean> flags = this.getOrCreateFlags();
+        flags.put(flag, value);
         return flag;
     }
 
-    public EnumSet<EntityFlag> putFlags(EnumSet<EntityFlag> flags) {
+    public EnumMap<EntityFlag, Boolean> putFlags(EnumMap<EntityFlag, Boolean> flags) {
         Objects.requireNonNull(flags, "flags");
         this.map.put(FLAGS, flags);
         this.map.put(FLAGS_2, flags);
@@ -107,7 +117,7 @@ public final class EntityDataMap implements Map<EntityDataType<?>, Object> {
         checkNotNull(value, "value was null for %s", key);
         checkArgument(key.isInstance(value), "value with type %s is not an instance of %s", value.getClass(), key);
         if (key == FLAGS || key == FLAGS_2) {
-            return this.putFlags((EnumSet<EntityFlag>) value);
+            return this.putFlags((EnumMap<EntityFlag, Boolean>) value);
         }
         return this.map.put(key, value);
     }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/entity/EntityDataTypes.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/entity/EntityDataTypes.java
@@ -7,17 +7,19 @@ import org.cloudburstmc.nbt.NbtMap;
 import org.cloudburstmc.protocol.bedrock.data.ParticleType;
 import org.cloudburstmc.protocol.bedrock.data.definitions.BlockDefinition;
 
+import java.util.EnumMap;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 
 @UtilityClass
 public class EntityDataTypes {
 
-    public static final EntityDataType<EnumSet<EntityFlag>> FLAGS = new EntityDataType<EnumSet<EntityFlag>>(EnumSet.class, "FLAGS") {
+    public static final EntityDataType<EnumMap<EntityFlag, Boolean>> FLAGS = new EntityDataType<EnumMap<EntityFlag, Boolean>>(EnumMap.class, "FLAGS") {
         @Override
         public boolean isInstance(Object value) {
-            return value instanceof EnumSet &&
-                    (((EnumSet<?>) value).isEmpty() || ((Set<?>) value).iterator().next() instanceof EntityFlag);
+            return value instanceof EnumMap &&
+                    (((EnumMap<?, ?>) value).isEmpty() || ((Map<?, ?>) value).keySet().iterator().next() instanceof EntityFlag);
         }
     };
     public static final EntityDataType<Integer> STRUCTURAL_INTEGRITY = new EntityDataType<>(Integer.class, "STRUCTURAL_INTEGRITY");
@@ -179,7 +181,13 @@ public class EntityDataTypes {
     public static final EntityDataType<Float> SITTING_AMOUNT = new EntityDataType<>(Float.class, "SITTING_AMOUNT");
     public static final EntityDataType<Float> SITTING_AMOUNT_PREVIOUS = new EntityDataType<>(Float.class, "SITTING_AMOUNT_PREVIOUS");
     public static final EntityDataType<Integer> EATING_COUNTER = new EntityDataType<>(Integer.class, "EATING_COUNTER");
-    public static final EntityDataType<EnumSet<EntityFlag>> FLAGS_2 = new EntityDataType<>(EnumSet.class, "FLAGS_2");
+    public static final EntityDataType<EnumMap<EntityFlag, Boolean>> FLAGS_2 = new EntityDataType<EnumMap<EntityFlag, Boolean>>(EnumMap.class, "FLAGS_2") {
+        @Override
+        public boolean isInstance(Object value) {
+            return value instanceof EnumMap &&
+                    (((EnumMap<?, ?>) value).isEmpty() || ((Map<?, ?>) value).keySet().iterator().next() instanceof EntityFlag);
+        }
+    };
     public static final EntityDataType<Float> LAYING_AMOUNT = new EntityDataType<>(Float.class, "LAYING_AMOUNT");
     public static final EntityDataType<Float> LAYING_AMOUNT_PREVIOUS = new EntityDataType<>(Float.class, "LAYING_AMOUNT_PREVIOUS");
     public static final EntityDataType<Integer> AREA_EFFECT_CLOUD_DURATION = new EntityDataType<>(Integer.class, "AREA_EFFECT_CLOUD_DURATION");

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/transformer/FlagTransformer.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/transformer/FlagTransformer.java
@@ -8,47 +8,122 @@ import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataMap;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.common.util.TypeMap;
 
-import java.util.EnumSet;
+import java.util.EnumMap;
+import java.util.Map;
 
-
+/**
+ * Transforms entity flags between their EnumMap representation and a packed long value.
+ * <p>
+ * Entity flags are split into multiple groups of 64 flags each (FLAGS, FLAGS_2).
+ * Each transformer instance handles one group, identified by its index:
+ * - index 0 = FLAGS (flags 0-63)
+ * - index 1 = FLAGS_2 (flags 64-127)
+ * <p>
+ */
 @RequiredArgsConstructor
-public final class FlagTransformer implements EntityDataTransformer<Long, EnumSet<EntityFlag>> {
+public final class FlagTransformer implements EntityDataTransformer<Long, EnumMap<EntityFlag, Boolean>> {
 
     private static final InternalLogger log = InternalLoggerFactory.getInstance(FlagTransformer.class);
 
     private final TypeMap<EntityFlag> typeMap;
+    /**
+     * The index of this flag group (0 for FLAGS, 1 for FLAGS_2)
+     */
     private final int index;
 
+    /**
+     * Serializes entity flags into a packed long value for network transmission.
+     * <p>
+     * Only flags within this transformer's range (determined by index) are processed.
+     * For example, if index=0, only flags 0-63 are handled; flags 64+ are ignored.
+     * <p>
+     * Returns null if no flags in this group are present, preventing unnecessary
+     * serialization of empty flag groups. This fixes the issue where missing flag
+     * groups would be written as zero, causing clients to incorrectly clear flags.
+     *
+     * @param helper the codec helper
+     * @param map the entity data map
+     * @param flags the complete flag map
+     * @return the packed long value containing flags for this group, or null if no flags exist
+     */
     @Override
-    public Long serialize(BedrockCodecHelper helper, EntityDataMap map, EnumSet<EntityFlag> flags) {
+    public Long serialize(BedrockCodecHelper helper, EntityDataMap map, EnumMap<EntityFlag, Boolean> flags) {
         long value = 0;
+        // Calculate the range of flag indices this transformer handles
         int lower = this.index * 64;
         int upper = lower + 64;
-        for (EntityFlag flag : flags) {
+        // Track whether any flags in this range exist (even if set to false)
+        boolean exists = false;
+
+        for (Map.Entry<EntityFlag, Boolean> entry : flags.entrySet()) {
+            EntityFlag flag = entry.getKey();
+            Boolean data = entry.getValue();
+            if (data == null) {
+                continue;
+            }
+
             int flagIndex = this.typeMap.getId(flag);
-            if (flagIndex >= lower && flagIndex < upper) {
+            if (flagIndex < lower || flagIndex >= upper) {
+                // This flag belongs to a different transformer (different index)
+                continue;
+            }
+
+            // Mark that at least one flag in this range exists
+            // This ensures we return a value (even if 0) rather than null
+            exists = true;
+
+            if (data) {
+                // Set the bit at the appropriate position (0-63 within this group)
+                // The & 0x3f masks the flag index to get its position within the 64-bit range
                 value |= 1L << (flagIndex & 0x3f);
             }
+            // If data is false, the bit remains 0 (default), but we still write the group
         }
 
-        return value;
+        // Return null if no flags in this range exist
+        // This prevents writing unnecessary flag groups and fixes unintentional flag resets on client
+        if (exists) {
+            return value;
+        }
+        return null;
     }
 
+    /**
+     * Deserializes a packed long value into individual entity flags.
+     * <p>
+     * Reads all 64 possible flag positions for this group, setting each flag
+     * to true or false based on the corresponding bit in the value.
+     *
+     * @param helper the codec helper
+     * @param map the entity data map to populate
+     * @param value the packed long value containing flag states
+     * @return the updated flag map
+     */
     @Override
-    public EnumSet<EntityFlag> deserialize(BedrockCodecHelper helper, EntityDataMap map, Long value) {
-        EnumSet<EntityFlag> flags = map.getOrCreateFlags();
+    public EnumMap<EntityFlag, Boolean> deserialize(BedrockCodecHelper helper, EntityDataMap map, Long value) {
+        EnumMap<EntityFlag, Boolean> flags = map.getOrCreateFlags();
 
-        int lower = index * 64;
+        // Calculate the range of flag indices this transformer handles
+        int lower = this.index * 64;
         int upper = lower + 64;
+
+        // Iterate through all 64 possible flags in this group
         for (int i = lower; i < upper; i++) {
+            EntityFlag flag = this.typeMap.getTypeUnsafe(i);
+            if (flag == null) {
+                // Flag index exists in the protocol but isn't mapped to an EntityFlag enum value
+                log.debug("Unknown entity flag detected with index {}", i);
+                continue;
+            }
+
+            // Get the bit position within this 64-bit group (0-63)
             int idx = i & 0x3f;
+
+            // Check if the bit at this position is set
             if ((value & (1L << idx)) != 0) {
-                EntityFlag flag = this.typeMap.getType(i);
-                if (flag != null) {
-                    flags.add(flag);
-                } else {
-                    log.debug("Unknown entity flag detected with index {}", i);
-                }
+                flags.put(flag, true);
+            } else {
+                flags.put(flag, false);
             }
         }
 

--- a/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/FlagSerializationTest.java
+++ b/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/FlagSerializationTest.java
@@ -1,0 +1,121 @@
+package org.cloudburstmc.protocol.bedrock.test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
+import org.cloudburstmc.protocol.bedrock.codec.v776.Bedrock_v776;
+import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataMap;
+import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
+import org.cloudburstmc.protocol.bedrock.transformer.FlagTransformer;
+import org.cloudburstmc.protocol.common.util.TypeMap;
+import org.junit.jupiter.api.AssertionFailureBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.util.EnumMap;
+
+
+public class FlagSerializationTest {
+    private static final BedrockCodecHelper CODEC_HELPER = Bedrock_v776.CODEC.createHelper();
+
+    private static final TypeMap<EntityFlag> ENTITY_FLAGS;
+
+    static {
+        try {
+            Field field = Bedrock_v776.class.getDeclaredField("ENTITY_FLAGS");
+            field.setAccessible(true);
+            ENTITY_FLAGS = (TypeMap<EntityFlag>) field.get(null);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+    private static final FlagTransformer FLAGS_TRANSFORMER = new FlagTransformer(ENTITY_FLAGS, 0);
+    private static final FlagTransformer FLAGS_2_TRANSFORMER = new FlagTransformer(ENTITY_FLAGS, 1);
+
+    @Test
+    public void testFlagSerialization() {
+        EntityDataMap dataMap = new EntityDataMap();
+        dataMap.setFlag(EntityFlag.BLOCKING, true); // FLAGS_2
+
+        testSerializationRoundTrip(dataMap);
+        verifyTransformerOutput(dataMap, false, true);
+
+        dataMap = new EntityDataMap();
+        dataMap.setFlag(EntityFlag.HAS_GRAVITY, true); // FLAGS
+
+        testSerializationRoundTrip(dataMap);
+        verifyTransformerOutput(dataMap, true, false);
+
+        dataMap = new EntityDataMap();
+        dataMap.setFlag(EntityFlag.HAS_GRAVITY, true); // FLAGS
+        dataMap.setFlag(EntityFlag.BLOCKING, true); // FLAGS_2
+
+        testSerializationRoundTrip(dataMap);
+        verifyTransformerOutput(dataMap, true, true);
+
+        dataMap = new EntityDataMap();
+        dataMap.setFlag(EntityFlag.HAS_GRAVITY, false); // FLAGS
+        dataMap.setFlag(EntityFlag.BLOCKING, true); // FLAGS_2
+
+        testSerializationRoundTrip(dataMap);
+        verifyTransformerOutput(dataMap, true, true);
+    }
+
+    private void verifyTransformerOutput(EntityDataMap dataMap, boolean shouldHaveFlags, boolean shouldHaveFlags2) {
+        Long serializedFlags = FLAGS_TRANSFORMER.serialize(CODEC_HELPER, dataMap, dataMap.getFlags());
+        if (shouldHaveFlags && serializedFlags == null) {
+            AssertionFailureBuilder.assertionFailure()
+                    .message("FLAGS")
+                    .expected("non-null value")
+                    .actual(null)
+                    .buildAndThrow();
+        } else if (!shouldHaveFlags && serializedFlags != null) {
+            AssertionFailureBuilder.assertionFailure()
+                    .message("FLAGS")
+                    .expected(null)
+                    .actual(serializedFlags)
+                    .buildAndThrow();
+        }
+
+        Long serializedFlags2 = FLAGS_2_TRANSFORMER.serialize(CODEC_HELPER, dataMap, dataMap.getFlags());
+        if (shouldHaveFlags2 && serializedFlags2 == null) {
+            AssertionFailureBuilder.assertionFailure()
+                    .message("FLAGS_2")
+                    .expected("non-null value")
+                    .actual(null)
+                    .buildAndThrow();
+        } else if (!shouldHaveFlags2 && serializedFlags2 != null) {
+            AssertionFailureBuilder.assertionFailure()
+                    .message("FLAGS_2")
+                    .expected(null)
+                    .actual(serializedFlags2)
+                    .buildAndThrow();
+        }
+    }
+
+    private void testSerializationRoundTrip(EntityDataMap originalDataMap) {
+        ByteBuf buffer = Unpooled.buffer();
+        CODEC_HELPER.writeEntityData(buffer, originalDataMap);
+
+        EntityDataMap deserializedDataMap = new EntityDataMap();
+        CODEC_HELPER.readEntityData(buffer, deserializedDataMap);
+
+        assertFlagsMatch(originalDataMap, deserializedDataMap);
+    }
+
+    private void assertFlagsMatch(EntityDataMap expected, EntityDataMap actual) {
+        EnumMap<EntityFlag, Boolean> expectedFlags = expected.getFlags();
+        EnumMap<EntityFlag, Boolean> actualFlags = actual.getFlags();
+        for (EntityFlag flag : EntityFlag.values()) {
+            Boolean actualValue = actualFlags.get(flag);
+            Boolean expectedValue = expectedFlags.get(flag);
+            if (expectedValue == null && Boolean.TRUE.equals(actualValue)) {
+                AssertionFailureBuilder.assertionFailure()
+                        .message("Flag " + flag + " should not be set")
+                        .expected(null)
+                        .actual(true)
+                        .buildAndThrow();
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.0.Beta10-SNAPSHOT
+version=3.0.0.Beta11-SNAPSHOT


### PR DESCRIPTION
Fixes https://github.com/WaterdogPE/WaterdogPE/issues/219#issuecomment-3382829653

When EntityDataMap is written, it writes both FLAGS and FLAGS_2 if either of them exists. However, if only one flag was present during reading (for example, if FLAGS_2 was sent without FLAGS), the missing flag would not be read but would still be written as zero during serialization. This creates a read/write mismatch that can be tested in ProxyPass by sending the read packet instead of the read buffer, forcing it to re-encode when sending to the client. This issue even affects BDS and causes client to see the missing flag set to zero, which clears it unintentionally.

This PR changes how EntityDataMap is serialized and what FlagTransformer returns when it finds no matching flags. FlagTransformer will now return null if there are no matching flags for the given part. When serializing EntityDataMap, it first collects the non-null serialized values, then writes them to the buffer.