### PR TITLE
Add missing entity flags

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v560/Bedrock_v560.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v560/Bedrock_v560.java
@@ -25,6 +25,7 @@ public class Bedrock_v560 extends Bedrock_v557 {
     protected static final TypeMap<EntityFlag> ENTITY_FLAGS = Bedrock_v557.ENTITY_FLAGS.toBuilder()
             .shift(46, 1)
             .insert(46, EntityFlag.CAN_DASH)
+            .insert(96, EntityFlag.OUT_OF_CONTROL)
             .insert(108, EntityFlag.HAS_DASH_COOLDOWN)
             .insert(109, EntityFlag.PUSH_TOWARDS_CLOSEST_SPACE)
             .build();

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v859/Bedrock_v859.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v859/Bedrock_v859.java
@@ -1,15 +1,31 @@
 package org.cloudburstmc.protocol.bedrock.codec.v859;
 
 import org.cloudburstmc.protocol.bedrock.codec.BedrockCodec;
+import org.cloudburstmc.protocol.bedrock.codec.EntityDataTypeMap;
 import org.cloudburstmc.protocol.bedrock.codec.v291.serializer.EntityEventSerializer_v291;
+import org.cloudburstmc.protocol.bedrock.codec.v844.BedrockCodecHelper_v844;
 import org.cloudburstmc.protocol.bedrock.codec.v844.Bedrock_v844;
 import org.cloudburstmc.protocol.bedrock.codec.v859.serializer.*;
 import org.cloudburstmc.protocol.bedrock.data.PacketRecipient;
+import org.cloudburstmc.protocol.bedrock.data.entity.EntityDataTypes;
 import org.cloudburstmc.protocol.bedrock.data.entity.EntityEventType;
+import org.cloudburstmc.protocol.bedrock.data.entity.EntityFlag;
 import org.cloudburstmc.protocol.bedrock.packet.*;
+import org.cloudburstmc.protocol.bedrock.transformer.FlagTransformer;
 import org.cloudburstmc.protocol.common.util.TypeMap;
 
 public class Bedrock_v859 extends Bedrock_v844 {
+
+    protected static final TypeMap<EntityFlag> ENTITY_FLAGS = Bedrock_v844.ENTITY_FLAGS
+            .toBuilder()
+            .insert(126, EntityFlag.BODY_ROTATION_LOCKED_TO_VEHICLE)
+            .build();
+
+    protected static final EntityDataTypeMap ENTITY_DATA = Bedrock_v844.ENTITY_DATA
+            .toBuilder()
+            .update(EntityDataTypes.FLAGS, new FlagTransformer(ENTITY_FLAGS, 0))
+            .update(EntityDataTypes.FLAGS_2, new FlagTransformer(ENTITY_FLAGS, 1))
+            .build();
 
     protected static final TypeMap<EntityEventType> ENTITY_EVENTS = Bedrock_v844.ENTITY_EVENTS.toBuilder()
             .insert(79, EntityEventType.SHAKE_WETNESS_STOP)
@@ -19,6 +35,7 @@ public class Bedrock_v859 extends Bedrock_v844 {
             .raknetProtocolVersion(11)
             .protocolVersion(859)
             .minecraftVersion("1.21.120")
+            .helper(() -> new BedrockCodecHelper_v844(ENTITY_DATA, GAME_RULE_TYPES, ITEM_STACK_REQUEST_TYPES, CONTAINER_SLOT_TYPES, PLAYER_ABILITIES, TEXT_PROCESSING_ORIGINS))
             .updateSerializer(AnimatePacket.class, AnimateSerializer_v859.INSTANCE)
             .updateSerializer(BiomeDefinitionListPacket.class, BiomeDefinitionListSerializer_v859.INSTANCE)
             .updateSerializer(CameraInstructionPacket.class, CameraInstructionSerializer_v859.INSTANCE)

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/entity/EntityFlag.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/entity/EntityFlag.java
@@ -178,5 +178,9 @@ public enum EntityFlag {
     /**
      * @since v843
      */
-    CAN_USE_VERTICAL_MOVEMENT_ACTION
+    CAN_USE_VERTICAL_MOVEMENT_ACTION,
+    /**
+     * @since v859
+     */
+    BODY_ROTATION_LOCKED_TO_VEHICLE
 }


### PR DESCRIPTION
Adds the missing entity flag `BODY_ROTATION_LOCKED_TO_VEHICLE` (`v859`) and properly registers the previously unregistered flag `OUT_OF_CONTROL` (`v560`).