### PR TITLE
Increased Animation Size

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/ImageData.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/skin/ImageData.java
@@ -21,7 +21,7 @@ public class ImageData {
     public static final int SKIN_128_64_SIZE = 128 * 64 * PIXEL_SIZE;
     public static final int SKIN_128_128_SIZE = 128 * 128 * PIXEL_SIZE;
     public static final int SKIN_PERSONA_SIZE = 256 * 256 * PIXEL_SIZE;
-    public static final int ANIMATION_SIZE = 1024 * 1024; // 1 MB
+    public static final int ANIMATION_SIZE = 1024 * 1024 * PIXEL_SIZE; // 4 MB
 
     private final int width;
     private final int height;


### PR DESCRIPTION
This should fix the problem with animation size.
Its unknown if 4 MB is the highest possible value, but its the highest we got while debugging.

Probably just the multiplication with PIXEL_SIZE was missing.

fixes #230