### PR TITLE
feat: support packet factory replacement and aliases

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/BedrockCodec.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/BedrockCodec.java
@@ -153,6 +153,28 @@ public final class BedrockCodec {
             return this;
         }
 
+        public <T extends BedrockPacket> Builder updateFactory(Class<T> packetClass, Supplier<? extends T> factory) {
+            BedrockPacketDefinition<T> info = (BedrockPacketDefinition<T>) packets.get(packetClass);
+            checkArgument(info != null, "Packet does not exist");
+            BedrockPacketDefinition<T> updatedInfo = new BedrockPacketDefinition<>(info.getId(), (Supplier<T>) factory, info.getSerializer(), info.getRecipient());
+
+            packets.replace(packetClass, info, updatedInfo);
+
+            return this;
+        }
+
+        public <T extends BedrockPacket, A extends T> Builder aliasPacket(Class<A> packetClass, Class<T> aliasedClass) {
+            checkNotNull(packetClass, "packetClass");
+            checkNotNull(aliasedClass, "aliasedClass");
+            checkArgument(!packets.containsKey(packetClass), "Packet class already registered");
+
+            BedrockPacketDefinition<? extends BedrockPacket> info = packets.get(aliasedClass);
+            checkArgument(info != null, "Packet does not exist");
+
+            packets.put(packetClass, info);
+            return this;
+        }
+
         public Builder retainPackets(Class<? extends BedrockPacket>... packets) {
             this.packets.keySet().retainAll(Arrays.asList(packets));
 


### PR DESCRIPTION
## TL;DR

Add two new `BedrockCodec.Builder` helpers:

- `updateFactory(...)` to replace the decode factory of an existing packet definition
- `aliasPacket(...)` to register an additional packet class key that reuses an existing definition

## Motivation

Some protocol extensions (e.g. https://github.com/AllayMC/ProtocolExtension) need to decode a stock packet ID into a subclass so extra vendor-
specific fields can be preserved, while still allowing callers to encode either the original parent packet type or the subclass instance through
the same codec.

The existing builder only supports replacing serializers, which is not enough for that use case.

## Changes

- add `updateFactory(Class<T>, Supplier<? extends T>)`
- add `aliasPacket(Class<A>, Class<T>)`

## Result

Extensions can now:

1. keep the original packet ID and serializer registration
2. swap the decode factory to return a subclass
3. alias that subclass back to the original definition for encoding

This keeps the upstream packet model unchanged while enabling vendor-specific packet subclasses in extension codecs.