### PR TITLE
Remove unused BookEditType enum in data package

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/BookEditType.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/data/BookEditType.java
@@ -1,9 +1,0 @@
-package org.cloudburstmc.protocol.bedrock.data;
-
-public enum BookEditType {
-    REPLACE_PAGE,
-    ADD_PAGE,
-    DELETE_PAGE,
-    SWAP_PAGES,
-    SIGN_BOOK
-}


### PR DESCRIPTION
BookEditPacket already has an Action enum defined within itself, which is also the one that's used in serializers, therefore this enum is a duplicate and can be deleted.