### PR TITLE
Fix Education Edition support

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/Bedrock_v898.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/Bedrock_v898.java
@@ -54,4 +54,15 @@ public class Bedrock_v898 extends Bedrock_v860 {
             .registerPacket(ClientboundDataStorePacket::new, ClientboundDataStoreSerializer_v898.INSTANCE, 330, PacketRecipient.CLIENT)
             .registerPacket(ServerboundDataStorePacket::new, ServerboundDataStoreSerializer_v898.INSTANCE, 332, PacketRecipient.SERVER)
             .build();
+
+    /**
+     * Education Edition codec variant for protocol 898 (Education 1.21.132).
+     * <p>
+     * Identical to {@link #CODEC} except the {@link StartGamePacket} serializer
+     * appends three Education-specific string fields at the end of LevelSettings.
+     * Use this codec for sessions with Minecraft Education Edition clients.
+     */
+    public static final BedrockCodec EDUCATION_CODEC = CODEC.toBuilder()
+            .updateSerializer(StartGamePacket.class, EducationStartGameSerializer_v898.INSTANCE)
+            .build();
 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/EducationStartGameSerializer_v898.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/EducationStartGameSerializer_v898.java
@@ -1,0 +1,36 @@
+package org.cloudburstmc.protocol.bedrock.codec.v898.serializer;
+
+import io.netty.buffer.ByteBuf;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
+import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
+
+/**
+ * Education Edition variant of the v898 StartGamePacket serializer.
+ * <p>
+ * Minecraft Education Edition 1.21.132 (protocol 898) expects three additional
+ * string fields at the end of LevelSettings, after {@code ownerId}. Without
+ * these fields, the Education client's deserializer reads into subsequent
+ * packet data and disconnects.
+ * <p>
+ * These fields are not present in standard Bedrock protocol 898.
+ */
+public class EducationStartGameSerializer_v898 extends StartGameSerializer_v898 {
+
+    public static final EducationStartGameSerializer_v898 INSTANCE = new EducationStartGameSerializer_v898();
+
+    @Override
+    protected void writeLevelSettings(ByteBuf buffer, BedrockCodecHelper helper, StartGamePacket packet) {
+        super.writeLevelSettings(buffer, helper, packet);
+        helper.writeString(buffer, packet.getEducationReferrerId());
+        helper.writeString(buffer, packet.getEducationCreatorWorldId());
+        helper.writeString(buffer, packet.getEducationCreatorId());
+    }
+
+    @Override
+    protected void readLevelSettings(ByteBuf buffer, BedrockCodecHelper helper, StartGamePacket packet) {
+        super.readLevelSettings(buffer, helper, packet);
+        packet.setEducationReferrerId(helper.readString(buffer));
+        packet.setEducationCreatorWorldId(helper.readString(buffer));
+        packet.setEducationCreatorId(helper.readString(buffer));
+    }
+}

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/StartGamePacket.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/packet/StartGamePacket.java
@@ -193,6 +193,27 @@ public class StartGamePacket implements BedrockPacket {
      */
     private String ownerId;
     /**
+     * Education Edition referrer ID. Only present in the Education Edition wire format.
+     * Written after {@link #ownerId} in LevelSettings by the education codec variant.
+     *
+     * @since v898 (Education Edition)
+     */
+    private String educationReferrerId = "";
+    /**
+     * Education Edition creator world ID. Only present in the Education Edition wire format.
+     * Written after {@link #educationReferrerId} in LevelSettings by the education codec variant.
+     *
+     * @since v898 (Education Edition)
+     */
+    private String educationCreatorWorldId = "";
+    /**
+     * Education Edition creator ID. Only present in the Education Edition wire format.
+     * Written after {@link #educationCreatorWorldId} in LevelSettings by the education codec variant.
+     *
+     * @since v898 (Education Edition)
+     */
+    private String educationCreatorId = "";
+    /**
      * @since v827
      */
     private boolean tickDeathSystemsEnabled;

--- a/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/EducationStartGameSerializerTest.java
+++ b/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/EducationStartGameSerializerTest.java
@@ -1,0 +1,83 @@
+package org.cloudburstmc.protocol.bedrock.test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.cloudburstmc.math.vector.Vector2f;
+import org.cloudburstmc.math.vector.Vector3f;
+import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.nbt.NbtList;
+import org.cloudburstmc.nbt.NbtMap;
+import org.cloudburstmc.nbt.NbtType;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
+import org.cloudburstmc.protocol.bedrock.codec.v898.Bedrock_v898;
+import org.cloudburstmc.protocol.bedrock.codec.v898.serializer.EducationStartGameSerializer_v898;
+import org.cloudburstmc.protocol.bedrock.data.AuthoritativeMovementMode;
+import org.cloudburstmc.protocol.bedrock.data.ChatRestrictionLevel;
+import org.cloudburstmc.protocol.bedrock.data.GamePublishSetting;
+import org.cloudburstmc.protocol.bedrock.data.GameType;
+import org.cloudburstmc.protocol.bedrock.data.PlayerPermission;
+import org.cloudburstmc.protocol.bedrock.data.SpawnBiomeType;
+import org.cloudburstmc.protocol.bedrock.packet.StartGamePacket;
+import org.cloudburstmc.protocol.common.util.OptionalBoolean;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EducationStartGameSerializerTest {
+    private static final BedrockCodecHelper CODEC_HELPER = Bedrock_v898.EDUCATION_CODEC.createHelper();
+    private static final EducationStartGameSerializer_v898 SERIALIZER = EducationStartGameSerializer_v898.INSTANCE;
+
+    @Test
+    public void testEducationFieldsSurviveRoundTrip() {
+        StartGamePacket packet = new StartGamePacket();
+        populateRequiredFields(packet);
+
+        packet.setEducationReferrerId("referrer-xyz");
+        packet.setEducationCreatorWorldId("world-abc");
+        packet.setEducationCreatorId("creator-123");
+
+        ByteBuf buf = Unpooled.buffer();
+        SERIALIZER.serialize(buf, CODEC_HELPER, packet);
+
+        StartGamePacket out = new StartGamePacket();
+        SERIALIZER.deserialize(buf, CODEC_HELPER, out);
+
+        assertEquals("referrer-xyz", out.getEducationReferrerId());
+        assertEquals("world-abc", out.getEducationCreatorWorldId());
+        assertEquals("creator-123", out.getEducationCreatorId());
+    }
+
+    @SuppressWarnings("deprecation") // authoritativeMovementMode is deprecated but still written by the v898 serializer chain
+    private static void populateRequiredFields(StartGamePacket packet) {
+        packet.setPlayerGameType(GameType.SURVIVAL);
+        packet.setPlayerPosition(Vector3f.ZERO);
+        packet.setRotation(Vector2f.ZERO);
+        packet.setLevelGameType(GameType.SURVIVAL);
+        packet.setDefaultSpawn(Vector3i.ZERO);
+        packet.setXblBroadcastMode(GamePublishSetting.NO_MULTI_PLAY);
+        packet.setPlatformBroadcastMode(GamePublishSetting.NO_MULTI_PLAY);
+        packet.setDefaultPlayerPermission(PlayerPermission.MEMBER);
+        packet.setLevelId("test-level-id");
+        packet.setLevelName("Test Level");
+        packet.setPremiumWorldTemplateId("");
+        packet.setMultiplayerCorrelationId("");
+        packet.setVanillaVersion("1.21.130");
+        packet.setBlockPalette(new NbtList<>(NbtType.COMPOUND, Collections.emptyList()));
+        packet.setForceExperimentalGameplay(OptionalBoolean.empty());
+        packet.setChatRestrictionLevel(ChatRestrictionLevel.NONE);
+        packet.setAuthoritativeMovementMode(AuthoritativeMovementMode.SERVER_WITH_REWIND);
+        packet.setSpawnBiomeType(SpawnBiomeType.DEFAULT);
+        packet.setCustomBiomeName("");
+        packet.setEducationProductionId("");
+        packet.setServerEngine("");
+        packet.setPlayerPropertyData(NbtMap.EMPTY);
+        packet.setWorldTemplateId(new UUID(0, 0));
+        packet.setServerId("");
+        packet.setWorldId("");
+        packet.setScenarioId("");
+        packet.setOwnerId("");
+    }
+}

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EducationTokenValidationResult.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EducationTokenValidationResult.java
@@ -1,0 +1,91 @@
+package org.cloudburstmc.protocol.bedrock.util;
+
+import lombok.ToString;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Instant;
+
+/**
+ * Result of verifying a Minecraft Education Edition server token.
+ * <p>
+ * Education tokens are the education equivalent of Mojang-signed login chains for
+ * standard Bedrock. They prove a player's identity within a Microsoft 365
+ * Education tenant via an RSA signature from Microsoft's education services (MESS).
+ * <p>
+ * Token format: {@code tenantId|oid|expiry|signatureHex}
+ * <dl>
+ *   <dt>{@code tenantId}</dt>
+ *   <dd>M365 Education tenant UUID identifying the school or district.</dd>
+ *   <dt>{@code oid}</dt>
+ *   <dd>Entra Object ID UUID. Unique per user per tenant and immutable.</dd>
+ *   <dt>{@code expiry}</dt>
+ *   <dd>ISO 8601 UTC timestamp after which the token is no longer valid.</dd>
+ *   <dt>{@code signatureHex}</dt>
+ *   <dd>RSA PKCS#1 v1.5 SHA-256 signature encoded as lowercase hex.</dd>
+ * </dl>
+ */
+@ToString
+public final class EducationTokenValidationResult {
+
+    public enum Status {
+        /** Signature is valid and the token has not expired. */
+        VALID,
+        /** Signature is valid but the expiry timestamp is in the past. */
+        EXPIRED,
+        /** Token is null, malformed, or the signature did not verify. */
+        INVALID
+    }
+
+    private final Status status;
+    private final String tenantId;
+    private final String oid;
+    private final Instant expiry;
+
+    private EducationTokenValidationResult(Status status, String tenantId, String oid, Instant expiry) {
+        this.status = status;
+        this.tenantId = tenantId;
+        this.oid = oid;
+        this.expiry = expiry;
+    }
+
+    static EducationTokenValidationResult valid(String tenantId, String oid, Instant expiry) {
+        return new EducationTokenValidationResult(Status.VALID, tenantId, oid, expiry);
+    }
+
+    static EducationTokenValidationResult expired(String tenantId, String oid, Instant expiry) {
+        return new EducationTokenValidationResult(Status.EXPIRED, tenantId, oid, expiry);
+    }
+
+    static EducationTokenValidationResult invalid() {
+        return new EducationTokenValidationResult(Status.INVALID, null, null, null);
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * The M365 Education tenant ID (school/district).
+     * Only available when status is {@link Status#VALID} or {@link Status#EXPIRED}.
+     */
+    public @Nullable String getTenantId() {
+        return tenantId;
+    }
+
+    /**
+     * The Entra Object ID of the user. Unique per user per tenant, immutable,
+     * and cryptographically verified via the education token signature.
+     * Only available when status is {@link Status#VALID} or {@link Status#EXPIRED}.
+     */
+    public @Nullable String getOid() {
+        return oid;
+    }
+
+    /**
+     * The token's expiry timestamp.
+     * Only available when status is {@link Status#VALID} or {@link Status#EXPIRED}.
+     */
+    public @Nullable Instant getExpiry() {
+        return expiry;
+    }
+}

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/util/EncryptionUtils.java
@@ -39,15 +39,34 @@ import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @UtilityClass
 public class EncryptionUtils {
     private static final ECPublicKey MOJANG_PUBLIC_KEY;
 
+    /**
+     * Microsoft's public key for verifying Education Edition server tokens,
+     * retrieved from the MESS (Minecraft Education Server Services) endpoint:
+     * {@code https://dedicatedserver.minecrafteduservices.com/public_keys/signing}
+     * <p>
+     * Used to verify the RSA signature on pipe-separated server tokens:
+     * {@code tenantId|oid|expiry|signatureHex}
+     * <p>
+     * This key plays the same role for Education Edition that {@link #MOJANG_PUBLIC_KEY}
+     * plays for standard Bedrock. Both are trust anchors for player identity.
+     * Mojang's EC key verifies Xbox Live login chains; this RSA key verifies
+     * education tokens containing the player's Entra tenant ID and Object ID.
+     */
+    private static final PublicKey EDUCATION_PUBLIC_KEY;
+
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final String MOJANG_PUBLIC_KEY_BASE64 =
             "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECRXueJeTDqNRRgJi/vlRufByu/2G0i2Ebt6YMar5QX/R0DIIyrJMcUpruK4QveTfJSTp3Shlq4Gk34cD/4GUWwkv0DVuzeuB+tXija7HBxii03NHDbPAD0AKnLr2wdAp";
+    private static final String EDUCATION_PUBLIC_KEY_BASE64 =
+            "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDsFCr3nD8N3TJxJZ7Y4g1Z20Son+fUWTSd2f/XyIil2mGGGx/yjRj6l0ntbROsec8MZoaLsBG0nWm9/WhJcdXvJewbdd+mCyy7WXyYQgJcJPZP3kgBDySZMUnaowlUmR9gxRr+LevCafZKQwb19nwJB0EUt+nQsWBbTe2SuIdCqQIDAQAB";
     private static final KeyPairGenerator KEY_PAIR_GEN;
 
     public static final String ALGORITHM_TYPE = AlgorithmIdentifiers.ECDSA_USING_P384_CURVE_AND_SHA384;
@@ -89,6 +108,8 @@ public class EncryptionUtils {
             KEY_PAIR_GEN = KeyPairGenerator.getInstance("EC");
             KEY_PAIR_GEN.initialize(new ECGenParameterSpec("secp384r1"));
             MOJANG_PUBLIC_KEY = parseKey(MOJANG_PUBLIC_KEY_BASE64);
+            EDUCATION_PUBLIC_KEY = KeyFactory.getInstance("RSA")
+                    .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(EDUCATION_PUBLIC_KEY_BASE64)));
         } catch (NoSuchAlgorithmException | InvalidAlgorithmParameterException | InvalidKeySpecException e) {
             throw new AssertionError("Unable to initialize required encryption", e);
         }
@@ -357,6 +378,24 @@ public class EncryptionUtils {
      * @throws JoseException invalid key pair provided
      */
     public static String createHandshakeJwt(KeyPair serverKeyPair, byte[] token) throws JoseException {
+        return createHandshakeJwt(serverKeyPair, token, null);
+    }
+
+    /**
+     * Create handshake JWS used in the {@link org.cloudburstmc.protocol.bedrock.packet.ServerToClientHandshakePacket}
+     * which completes the encryption handshake.
+     * <p>
+     * For Education Edition clients, the {@code signedToken} parameter must contain the
+     * education server token. Education clients verify this token during the handshake
+     * and reject the connection if it is missing or invalid.
+     *
+     * @param serverKeyPair used to sign the JWT
+     * @param token         salt for the encryption handshake
+     * @param signedToken   education server token, or null for standard Bedrock
+     * @return signed JWS object
+     * @throws JoseException invalid key pair provided
+     */
+    public static String createHandshakeJwt(KeyPair serverKeyPair, byte[] token, String signedToken) throws JoseException {
         JsonWebSignature signature = new JsonWebSignature();
         signature.setAlgorithmHeaderValue(ALGORITHM_TYPE);
         signature.setHeader(
@@ -367,6 +406,9 @@ public class EncryptionUtils {
 
         JwtClaims claims = new JwtClaims();
         claims.setClaim("salt", Base64.getEncoder().encodeToString(token));
+        if (signedToken != null) {
+            claims.setClaim("signedToken", signedToken);
+        }
         signature.setPayload(claims.toJson());
 
         return signature.getCompactSerialization();
@@ -390,6 +432,181 @@ public class EncryptionUtils {
      */
     public static ECPublicKey getMojangPublicKey() {
         return MOJANG_PUBLIC_KEY;
+    }
+
+    /**
+     * Microsoft's public key used to verify Education Edition server tokens.
+     *
+     * @return Education RSA public key
+     */
+    public static PublicKey getEducationPublicKey() {
+        return EDUCATION_PUBLIC_KEY;
+    }
+
+    /**
+     * Validate the Education Edition login JWT end-to-end.
+     * <p>
+     * Education Edition clients send an outer self-signed JWT (the EduTokenChain) in place
+     * of the standard Bedrock identity chain. Its payload carries a single {@code chain}
+     * field containing the MESS-signed server token that actually proves player identity.
+     * <p>
+     * This method plays the same role for Education Edition that {@link #validatePayload}
+     * plays for standard Bedrock. It is the top-level entry point: it unwraps the outer
+     * education JWT via {@link #extractServerTokenFromEduTokenChain} and then verifies the
+     * inner server token via {@link #validateEducationToken}.
+     *
+     * @param eduTokenChain the outer education login JWT as a compact serialization string
+     * @return the validation result; {@link EducationTokenValidationResult.Status#INVALID}
+     *         is returned if the JWT has no extractable server token
+     * @throws JoseException the outer JWT is malformed or its payload is not valid JSON
+     * @throws NoSuchAlgorithmException SHA256withRSA is not available
+     * @throws InvalidKeyException the education public key is not a valid RSA key
+     */
+    public static EducationTokenValidationResult validateEducationPayload(String eduTokenChain)
+            throws JoseException, NoSuchAlgorithmException, InvalidKeyException {
+        String serverToken = extractServerTokenFromEduTokenChain(eduTokenChain);
+        if (serverToken == null) {
+            return EducationTokenValidationResult.invalid();
+        }
+        return validateEducationToken(serverToken);
+    }
+
+    /**
+     * Extract the inner server token from an Education Edition login JWT (EduTokenChain).
+     * <p>
+     * The EduTokenChain payload contains a {@code chain} field whose value is the
+     * pipe-separated MESS-signed server token ({@code tenantId|oid|expiry|signatureHex}).
+     * This method peels the JWT structure and returns that value without verifying anything.
+     * <p>
+     * <b>Security:</b> the outer JWT's signature is intentionally NOT verified here.
+     * Education login JWTs are self-signed with an ephemeral client key, so verifying
+     * the outer signature only proves the client signed its own JWT and establishes
+     * nothing about player identity. The inner {@code chain} field is the load-bearing
+     * credential and carries its own MESS RSA signature, which is verified by
+     * {@link #validateEducationToken}. Any caller that extracts additional fields from
+     * the outer JWT must treat those fields as untrusted unless a separate verification
+     * path is established for them.
+     *
+     * @param eduTokenChain the outer education login JWT as a compact serialization string
+     * @return the inner server token, or {@code null} if the input is null/empty or the
+     *         {@code chain} field is absent or not a string
+     * @throws JoseException the input is not a valid JWT or its payload is not valid JSON
+     */
+    public static String extractServerTokenFromEduTokenChain(String eduTokenChain) throws JoseException {
+        if (eduTokenChain == null || eduTokenChain.isEmpty()) {
+            return null;
+        }
+        JsonWebSignature jws = new JsonWebSignature();
+        jws.setCompactSerialization(eduTokenChain);
+        Map<String, Object> payload = JsonUtil.parseJson(jws.getUnverifiedPayload());
+        Object chain = payload.get("chain");
+        return chain instanceof String ? (String) chain : null;
+    }
+
+    /**
+     * Validate an education server token signed by Microsoft's MESS service.
+     * <p>
+     * Token format: {@code tenantId|oid|expiry|signatureHex} where the signature
+     * is RSA PKCS#1 v1.5 SHA-256 over {@code tenantId|oid|expiry} as UTF-8 bytes.
+     * <p>
+     * This method plays the same role for Education Edition that
+     * {@link #validateChain(List)} plays for standard Bedrock. It verifies player
+     * identity against {@link #EDUCATION_PUBLIC_KEY} in the same manner that
+     * {@code validateChain} verifies identity against {@link #MOJANG_PUBLIC_KEY}.
+     * <p>
+     * This inner MESS signature is the sole cryptographic anchor for education
+     * player identity. Other apparent verification points in the education
+     * login flow do not provide identity proof:
+     * <ul>
+     *   <li>The Bedrock login chain for education clients is a single self-signed
+     *       JWT with an ephemeral per-session EC P-384 key. No Mojang root signs
+     *       it, so {@link ChainValidationResult#signed()} returns false and the
+     *       chain's claims prove only that the client holds the private half of
+     *       a public key they themselves generated.</li>
+     *   <li>The chain's {@code extraData.identity} is a client-generated
+     *       per-session UUID, unrelated to the Entra Object ID and unanchored
+     *       to any external authority.</li>
+     *   <li>The {@code EduTokenChain} JWT that wraps this token in the login
+     *       packet is itself signed with another client-generated key whose
+     *       public half is embedded inline via the {@code x5u} header, not
+     *       fetched from a remote trust anchor. Verifying the outer signature
+     *       proves only that the client signed its own wrapper. An attacker
+     *       who captures a valid inner token can re-wrap it with a fresh
+     *       ephemeral key and produce a structurally valid outer JWT without
+     *       Microsoft's involvement.</li>
+     * </ul>
+     * Only the inner signature over {@code tenantId|oid|expiry} binds the
+     * token to a fixed Microsoft-controlled trust anchor
+     * ({@link #EDUCATION_PUBLIC_KEY}).
+     * Verifying it is the only mechanism that attests to player identity
+     * against a party the client cannot impersonate.
+     *
+     * @param serverToken the pipe-separated education server token
+     * @return validation result with status, tenant ID, OID, and expiry
+     * @throws NoSuchAlgorithmException SHA256withRSA is not available
+     * @throws InvalidKeyException the education public key is not a valid RSA key
+     */
+    public static EducationTokenValidationResult validateEducationToken(String serverToken)
+            throws NoSuchAlgorithmException, InvalidKeyException {
+        if (serverToken == null) {
+            return EducationTokenValidationResult.invalid();
+        }
+
+        String[] parts = serverToken.split("\\|", -1);
+        if (parts.length != 4) {
+            return EducationTokenValidationResult.invalid();
+        }
+
+        byte[] signatureBytes;
+        try {
+            signatureBytes = hexToBytes(parts[3]);
+        } catch (IllegalArgumentException e) {
+            return EducationTokenValidationResult.invalid();
+        }
+
+        Signature sig = Signature.getInstance("SHA256withRSA");
+        sig.initVerify(EDUCATION_PUBLIC_KEY);
+        try {
+            sig.update((parts[0] + "|" + parts[1] + "|" + parts[2]).getBytes(StandardCharsets.UTF_8));
+            if (!sig.verify(signatureBytes)) {
+                return EducationTokenValidationResult.invalid();
+            }
+        } catch (SignatureException e) {
+            return EducationTokenValidationResult.invalid();
+        }
+
+        // Mirrors the Education client: parsed_expiry < now is expired;
+        // failed parse is also treated as expired (client forces value to 0).
+        Instant expiry;
+        try {
+            expiry = Instant.parse(parts[2]);
+        } catch (DateTimeParseException e) {
+            return EducationTokenValidationResult.expired(parts[0], parts[1], Instant.EPOCH);
+        }
+
+        if (Instant.now().isAfter(expiry)) {
+            return EducationTokenValidationResult.expired(parts[0], parts[1], expiry);
+        }
+
+        try {
+            UUID.fromString(parts[0]);
+            UUID.fromString(parts[1]);
+        } catch (IllegalArgumentException e) {
+            return EducationTokenValidationResult.invalid();
+        }
+
+        return EducationTokenValidationResult.valid(parts[0], parts[1], expiry);
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        if ((hex.length() & 1) != 0) {
+            throw new IllegalArgumentException("odd-length hex string");
+        }
+        byte[] bytes = new byte[hex.length() / 2];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) Integer.parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        return bytes;
     }
 
     public static Cipher createCipher(boolean gcm, boolean encrypt, SecretKey key) {


### PR DESCRIPTION
The library already maintains packets, data types, and fields for Education Edition, but Education clients can't actually use any of it because they desync on `StartGamePacket` before any subsequent packets can be exchanged. Education Edition's wire format has three extra string fields at the end of LevelSettings that the current serializer doesn't write, causing the client's deserializer to read into subsequent packet data and disconnect. This PR fixes the serialization and adds the auth utilities needed to verify Education login tokens.
 
### Changes
 
**Codec:** Three new fields on `StartGamePacket`, an `EducationStartGameSerializer_v898` extending the existing one, and `Bedrock_v898.EDUCATION_CODEC` as a parallel constant.
 
**Auth:** Education clients don't use Xbox Live. Their login chains are self-signed and `validateChain` always returns `signed=false`. This adds validation for Microsoft's education services (MESS) signed tokens and a `createHandshakeJwt` overload for the `signedToken` claim education clients require, following the existing patterns in `EncryptionUtils`.
 
When Education updates to a newer protocol version, adding support requires only a new serializer and `EDUCATION_CODEC` constant on that version's class.
 
I have detailed documentation on the Education Edition protocol differences and authentication system if needed.