### PR TITLE
Fix TextPacket.needsTranslation not being preserved across deserializ…

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/TextSerializer_v291.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v291/serializer/TextSerializer_v291.java
@@ -54,6 +54,7 @@ public class TextSerializer_v291 implements BedrockPacketSerializer<TextPacket> 
         packet.setType(type);
         TextConverter converter = helper.getTextConverter();
         boolean needsTranslation = buffer.readBoolean();
+        packet.setNeedsTranslation(needsTranslation);
 
         switch (type) {
             case CHAT:

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v332/serializer/TextSerializer_v332.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v332/serializer/TextSerializer_v332.java
@@ -58,6 +58,7 @@ public class TextSerializer_v332 implements BedrockPacketSerializer<TextPacket> 
         packet.setType(type);
         TextConverter converter = helper.getTextConverter();
         boolean needsTranslation = buffer.readBoolean();
+        packet.setNeedsTranslation(needsTranslation);
 
         switch (type) {
             case CHAT:

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v554/serializer/TextSerializer_v554.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v554/serializer/TextSerializer_v554.java
@@ -56,6 +56,7 @@ public class TextSerializer_v554 extends TextSerializer_v332 {
         packet.setType(type);
         TextConverter converter = helper.getTextConverter();
         boolean needsTranslation = buffer.readBoolean();
+        packet.setNeedsTranslation(needsTranslation);
 
         switch (type) {
             case CHAT:

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/TextSerializer_v898.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/TextSerializer_v898.java
@@ -116,6 +116,7 @@ public class TextSerializer_v898 extends TextSerializer_v685 {
     public void deserialize(ByteBuf buffer, BedrockCodecHelper helper, TextPacket packet) {
         TextConverter converter = helper.getTextConverter();
         boolean needsTranslation = buffer.readBoolean();
+        packet.setNeedsTranslation(needsTranslation);
 
         switch (buffer.readByte()) {
             case 0: // MessageOnly

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v924/serializer/TextSerializer_v924.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v924/serializer/TextSerializer_v924.java
@@ -98,6 +98,7 @@ public class TextSerializer_v924 extends TextSerializer_v898 {
     public void deserialize(ByteBuf buffer, BedrockCodecHelper helper, TextPacket packet) {
         TextConverter converter = helper.getTextConverter();
         boolean needsTranslation = buffer.readBoolean();
+        packet.setNeedsTranslation(needsTranslation);
 
         switch (buffer.readByte()) {
             case 0: // MessageOnly


### PR DESCRIPTION
Fix TextPacket.needsTranslation not preserved across deserialize/re-serialize

## Summary

All TextSerializer deserialize() methods read needsTranslation from the wire but never store it back to the packet object. After deserialization, packet.isNeedsTranslation() always returns false, regardless of what the server actually sent.

This causes translation keys (e.g. %multiplayer.player.joined) to be incorrectly tagged as needsTranslation=false when the packet passes through any proxy that deserializes and re-serializes it.

## Fix

Added packet.setNeedsTranslation(needsTranslation) after buffer.readBoolean() in:

- v291 / v332 / v554 / v898 / v924