### PR TITLE
Remove up to 50 ms of outbound packet latency

### DIFF
--- a/bedrock-connection/build.gradle.kts
+++ b/bedrock-connection/build.gradle.kts
@@ -2,6 +2,8 @@ dependencies {
     api(projects.bedrockCodec)
     api(libs.netty.transport.raknet)
     api(libs.snappy)
+
+    testImplementation(libs.junit)
 }
 
 tasks.jar {

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPeer.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPeer.java
@@ -6,7 +6,6 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.ReferenceCountUtil;
-import io.netty.util.concurrent.ScheduledFuture;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -49,11 +48,13 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
 
     private static final InternalLogger log = InternalLoggerFactory.getInstance(BedrockPeer.class);
 
+    static final long BATCH_FLUSH_DELAY_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+
     protected final Int2ObjectMap<BedrockSession> sessions = new Int2ObjectOpenHashMap<>();
     protected final Queue<BedrockPacketWrapper> packetQueue = PlatformDependent.newMpscQueue();
     protected final Channel channel;
     protected final BedrockSessionFactory sessionFactory;
-    protected ScheduledFuture<?> tickFuture;
+    final AtomicBoolean flushScheduled = new AtomicBoolean();
     protected AtomicBoolean closed = new AtomicBoolean();
     protected AtomicBoolean closing = new AtomicBoolean();
 
@@ -85,22 +86,43 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
         this.sessions.remove(session.subClientId, session);
     }
 
-    protected void onTick() {
+    protected void flushPacketQueue() {
         if (this.closing.get() || this.closed.get()) {
+            this.flushScheduled.set(false);
             return;
         }
-        flushQueue();
+
+        try {
+            BedrockPacketWrapper packet;
+            boolean wrotePacket = false;
+            while ((packet = this.packetQueue.poll()) != null) {
+                this.channel.write(packet);
+                wrotePacket = true;
+            }
+            if (wrotePacket) {
+                this.channel.flush();
+            }
+        } finally {
+            this.flushScheduled.set(false);
+
+            // A producer can enqueue after the final poll but before the flag is cleared.
+            if (!this.closing.get() && !this.closed.get() && !this.packetQueue.isEmpty()) {
+                this.schedulePacketFlush();
+            }
+        }
     }
 
-    protected void flushQueue() {
-        if (this.packetQueue.isEmpty()) {
+    private void schedulePacketFlush() {
+        if (this.closing.get() || this.closed.get() || !this.flushScheduled.compareAndSet(false, true)) {
             return;
         }
-        BedrockPacketWrapper packet;
-        while ((packet = this.packetQueue.poll()) != null) {
-            this.channel.write(packet);
+
+        try {
+            this.channel.eventLoop().schedule(this::flushPacketQueue, BATCH_FLUSH_DELAY_NANOS, TimeUnit.NANOSECONDS);
+        } catch (RuntimeException exception) {
+            this.flushScheduled.set(false);
+            throw exception;
         }
-        this.channel.flush();
     }
 
     private void onRakNetDisconnect(ChannelHandlerContext ctx, RakDisconnectReason reason) {
@@ -111,7 +133,8 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
     }
 
     private void free() {
-        for (BedrockPacketWrapper wrapper : this.packetQueue) {
+        BedrockPacketWrapper wrapper;
+        while ((wrapper = this.packetQueue.poll()) != null) {
             ReferenceCountUtil.safeRelease(wrapper);
         }
     }
@@ -122,6 +145,7 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
             return;
         }
         this.packetQueue.add(BedrockPacketWrapper.create(0, senderClientId, targetClientId, packet, null));
+        this.schedulePacketFlush();
     }
 
     public void sendPacketImmediately(int senderClientId, int targetClientId, BedrockPacket packet) {
@@ -243,11 +267,6 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        if (this.tickFuture != null) {
-            this.tickFuture.cancel(false);
-            this.tickFuture = null;
-        }
-
         for (BedrockSession session : this.sessions.values()) {
             try {
                 session.onClose();
@@ -291,7 +310,6 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
     @Override
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         this.sessions.put(0, this.sessionFactory.createSession(this, 0));
-        this.tickFuture = this.channel.eventLoop().scheduleAtFixedRate(this::onTick, 50, 50, TimeUnit.MILLISECONDS);
     }
 
     @Override

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPeer.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPeer.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.DecoderException;
 import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.SystemPropertyUtil;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -51,7 +52,28 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
 
     private static final InternalLogger log = InternalLoggerFactory.getInstance(BedrockPeer.class);
 
-    static final long BATCH_FLUSH_DELAY_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+    static final String BATCH_FLUSH_DELAY_PROPERTY = "org.cloudburstmc.protocol.bedrock.batchFlushDelayMillis";
+    static final int DEFAULT_BATCH_FLUSH_DELAY_MILLIS = 1;
+    static final int MAX_BATCH_FLUSH_DELAY_MILLIS = 50;
+
+    /**
+     * How long the first packet of a burst waits in the outbound queue for the rest
+     * of that burst to join its batch. A producer that hands its packets over
+     * together still gets a single batch at any positive delay; the wait only
+     * splits bursts that are emitted over a longer stretch than the window, and
+     * each resulting batch is then compressed on its own. A wider window trades
+     * latency for compression efficiency on such producers, while zero disables
+     * coalescing across event loop iterations. Configurable in milliseconds with
+     * the {@value #BATCH_FLUSH_DELAY_PROPERTY} system property, read once when this
+     * class is initialized.
+     * <p>
+     * Note that a window is not equivalent to the periodic flush this replaced: it
+     * starts at the first enqueue, so a burst handed over together always waits the
+     * full window, where a periodic tick of the same period waited half of it on
+     * average.
+     */
+    static final long BATCH_FLUSH_DELAY_NANOS = TimeUnit.MILLISECONDS.toNanos(
+            resolveFlushDelayMillis(SystemPropertyUtil.getInt(BATCH_FLUSH_DELAY_PROPERTY, DEFAULT_BATCH_FLUSH_DELAY_MILLIS)));
     static final long REJECTED_RETRY_DELAY_MILLIS = 10;
 
     protected final Int2ObjectMap<BedrockSession> sessions = new Int2ObjectOpenHashMap<>();
@@ -67,6 +89,20 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
     public BedrockPeer(Channel channel, BedrockSessionFactory sessionFactory) {
         this.channel = channel;
         this.sessionFactory = sessionFactory;
+    }
+
+    /**
+     * Returns the configured flush delay, falling back to the default when it is
+     * outside the supported range. Out of range values are rejected rather than
+     * saturated so a typo cannot silently pick the nearest bound.
+     */
+    static int resolveFlushDelayMillis(int delay) {
+        if (delay < 0 || delay > MAX_BATCH_FLUSH_DELAY_MILLIS) {
+            log.warn("Unable to use the flush delay system property '{}':{} - using the default value: {}",
+                    BATCH_FLUSH_DELAY_PROPERTY, delay, DEFAULT_BATCH_FLUSH_DELAY_MILLIS);
+            return DEFAULT_BATCH_FLUSH_DELAY_MILLIS;
+        }
+        return delay;
     }
 
     protected void onBedrockPacket(BedrockPacketWrapper wrapper) {

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPeer.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/BedrockPeer.java
@@ -6,6 +6,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.DecoderException;
 import io.netty.util.ReferenceCountUtil;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.util.internal.PlatformDependent;
 import io.netty.util.internal.logging.InternalLogger;
 import io.netty.util.internal.logging.InternalLoggerFactory;
@@ -33,8 +34,10 @@ import org.cloudburstmc.protocol.bedrock.util.EncryptionUtils;
 
 import javax.crypto.SecretKey;
 import java.net.SocketAddress;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -49,12 +52,15 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
     private static final InternalLogger log = InternalLoggerFactory.getInstance(BedrockPeer.class);
 
     static final long BATCH_FLUSH_DELAY_NANOS = TimeUnit.MILLISECONDS.toNanos(1);
+    static final long REJECTED_RETRY_DELAY_MILLIS = 10;
 
     protected final Int2ObjectMap<BedrockSession> sessions = new Int2ObjectOpenHashMap<>();
     protected final Queue<BedrockPacketWrapper> packetQueue = PlatformDependent.newMpscQueue();
     protected final Channel channel;
     protected final BedrockSessionFactory sessionFactory;
     final AtomicBoolean flushScheduled = new AtomicBoolean();
+    final AtomicBoolean flushRetryScheduled = new AtomicBoolean();
+    final AtomicBoolean closeRetryScheduled = new AtomicBoolean();
     protected AtomicBoolean closed = new AtomicBoolean();
     protected AtomicBoolean closing = new AtomicBoolean();
 
@@ -87,7 +93,15 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
     }
 
     protected void flushPacketQueue() {
-        if (this.closing.get() || this.closed.get()) {
+        if (this.closed.get()) {
+            this.flushScheduled.set(false);
+            // Release anything enqueued after onClose() drained the queue.
+            this.free();
+            return;
+        }
+        if (this.closing.get()) {
+            // Once a disconnect is requested nothing more is written; the queue
+            // is freed by onClose(), which is guaranteed to follow.
             this.flushScheduled.set(false);
             return;
         }
@@ -112,17 +126,72 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
         }
     }
 
-    private void schedulePacketFlush() {
-        if (this.closing.get() || this.closed.get() || !this.flushScheduled.compareAndSet(false, true)) {
+    void schedulePacketFlush() {
+        if (this.closed.get()) {
+            // sendPacket() can race the door gate, enqueueing after onClose() has
+            // already drained the queue and leaving the wrapper with no flush
+            // task to release it. Hand the cleanup to the event loop rather than
+            // draining here: the queue is MPSC, so drains must stay serialized.
+            try {
+                this.channel.eventLoop().execute(this::free);
+            } catch (RejectedExecutionException exception) {
+                // Rejection means the loop is shut down or its task queue is
+                // full; either way it may still be running tasks, and other
+                // producers can land here concurrently. free() is synchronized
+                // to keep this drain mutually exclusive with those.
+                this.free();
+            }
+            return;
+        }
+        // Once closing, nothing schedules; onClose() frees the queue.
+        if (this.closing.get() || !this.flushScheduled.compareAndSet(false, true)) {
             return;
         }
 
         try {
-            this.channel.eventLoop().schedule(this::flushPacketQueue, BATCH_FLUSH_DELAY_NANOS, TimeUnit.NANOSECONDS);
+            this.scheduleFlushTask();
+        } catch (RejectedExecutionException exception) {
+            // The loop refused the task: it is shutting down, or a bounded task
+            // queue is momentarily full while the peer stays live. The wrapper
+            // stays owned by the packet queue, but without a retry a live peer
+            // with no further sends would strand it until close, so retry off
+            // the global executor, which never rejects. The CAS keeps the retry
+            // deduplicated to one chain per peer; otherwise every send during
+            // saturation would spawn its own self reproducing retry, turning
+            // loop backpressure into an unbounded global executor backlog. The
+            // chain ends once the loop accepts a flush or the peer closes.
+            this.flushScheduled.set(false);
+            if (this.flushRetryScheduled.compareAndSet(false, true)) {
+                this.scheduleRejectedRetry(this::retryPacketFlush);
+            }
         } catch (RuntimeException exception) {
             this.flushScheduled.set(false);
             throw exception;
         }
+    }
+
+    private void retryPacketFlush() {
+        this.flushRetryScheduled.set(false);
+        if (this.closing.get() || this.closed.get() || this.packetQueue.isEmpty()) {
+            return;
+        }
+        this.schedulePacketFlush();
+    }
+
+    void scheduleFlushTask() {
+        this.channel.eventLoop().schedule(this::flushPacketQueue, BATCH_FLUSH_DELAY_NANOS, TimeUnit.NANOSECONDS);
+    }
+
+    void executeOnEventLoop(Runnable task) {
+        this.channel.eventLoop().execute(task);
+    }
+
+    boolean isOnEventLoop() {
+        return this.channel.eventLoop().inEventLoop();
+    }
+
+    void scheduleRejectedRetry(Runnable retry) {
+        GlobalEventExecutor.INSTANCE.schedule(retry, REJECTED_RETRY_DELAY_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     private void onRakNetDisconnect(ChannelHandlerContext ctx, RakDisconnectReason reason) {
@@ -132,7 +201,18 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
         }
     }
 
-    private void free() {
+    /**
+     * Releases every queued packet wrapper. The queue is MPSC, so drains must be
+     * mutually exclusive. Most callers run on the event loop (onClose(), the
+     * closed branches of flushPacketQueue() and schedulePacketFlush()), but when
+     * the loop rejects work during shutdown a producer thread drains directly,
+     * and the loop may still be running its final tasks at that point, so the
+     * loop thread alone cannot serialize this. The lock does. Only close time
+     * paths call this, never the flush hot path. Repeated invocation is only
+     * safe because the drain is a destructive poll; iterating instead would
+     * release the same wrappers twice.
+     */
+    private synchronized void free() {
         BedrockPacketWrapper wrapper;
         while ((wrapper = this.packetQueue.poll()) != null) {
             ReferenceCountUtil.safeRelease(wrapper);
@@ -231,10 +311,27 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
     }
 
     public void close(CharSequence reason) {
-        if (this.channel.eventLoop().inEventLoop()) {
+        if (this.isOnEventLoop()) {
             this.close0(reason, false);
-        } else {
-            this.channel.eventLoop().execute(() -> this.close0(reason, false));
+            return;
+        }
+        // The session map is event loop confined, so the close must run there.
+        // Rejection means the loop is shut down or a bounded task queue is full
+        // while the channel may still be open, so retry off the never rejecting
+        // global executor until the close lands or the channel dies on its own;
+        // dropping the task would silently lose the disconnect reason. The CAS
+        // keeps the retry deduplicated; the first reason wins.
+        try {
+            this.executeOnEventLoop(() -> this.close0(reason, false));
+        } catch (RejectedExecutionException exception) {
+            if (this.closeRetryScheduled.compareAndSet(false, true)) {
+                this.scheduleRejectedRetry(() -> {
+                    this.closeRetryScheduled.set(false);
+                    if (!this.closing.get() && !this.closed.get() && this.channel.isOpen()) {
+                        this.close(reason);
+                    }
+                });
+            }
         }
     }
 
@@ -267,15 +364,22 @@ public class BedrockPeer extends ChannelInboundHandlerAdapter {
             return;
         }
 
-        for (BedrockSession session : this.sessions.values()) {
-            try {
-                session.onClose();
-            } catch (Exception e) {
-                log.error("Exception whilst closing session", e);
+        try {
+            // Sessions remove themselves from the map in onClose(), and the open
+            // addressing map must not be mutated mid iteration (skipped entries,
+            // iterator NPE), so iterate a snapshot. An escaping exception here
+            // could otherwise never be retried: closed is already latched.
+            for (BedrockSession session : new ArrayList<>(this.sessions.values())) {
+                try {
+                    session.onClose();
+                } catch (Exception e) {
+                    log.error("Exception whilst closing session", e);
+                }
             }
+        } finally {
+            this.sessions.clear();
+            this.free();
         }
-
-        this.free();
     }
 
     public boolean isConnected() {

--- a/bedrock-connection/src/test/java/org/cloudburstmc/protocol/bedrock/BedrockPeerBatchingTest.java
+++ b/bedrock-connection/src/test/java/org/cloudburstmc/protocol/bedrock/BedrockPeerBatchingTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -128,6 +129,185 @@ public class BedrockPeerBatchingTest {
         testPeer.channel.finishAndReleaseAll();
     }
 
+    @Test
+    public void sendPacketDuringClosingIsReleasedNotQueued() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+
+        testPeer.peer.close("bye");
+
+        testPeer.peer.sendPacket(0, 0, new PlayStatusPacket());
+
+        assertTrue(testPeer.peer.closing.get());
+        assertTrue(testPeer.peer.packetQueue.isEmpty());
+        advanceToFlush(testPeer.channel);
+        assertNull(testPeer.channel.readOutbound());
+        testPeer.peer.onClose();
+        testPeer.channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void closingStopsFlushingAndOnCloseFreesTheQueue() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+        testPeer.peer.sendPacket(0, 0, new PlayStatusPacket());
+        BedrockPacketWrapper queuedWrapper = testPeer.peer.packetQueue.peek();
+
+        testPeer.peer.close("bye");
+
+        // A flush arriving after the close request must not write; the queue is
+        // freed by onClose(), never delivered.
+        testPeer.peer.flushPacketQueue();
+        assertNull(testPeer.channel.readOutbound());
+        assertEquals(0, counter.flushes);
+        assertFalse(testPeer.peer.packetQueue.isEmpty());
+
+        testPeer.peer.onClose();
+        assertTrue(testPeer.peer.packetQueue.isEmpty());
+        assertEquals(0, queuedWrapper.refCnt());
+        testPeer.channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void packetEnqueuedAfterCloseIsReleased() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+
+        testPeer.channel.close();
+        testPeer.peer.onClose();
+
+        // Simulates a producer that passed the sendPacket() door gate just before
+        // closing was set: the wrapper is enqueued with no flush task left.
+        testPeer.peer.packetQueue.add(BedrockPacketWrapper.create(0, 0, 0, new PlayStatusPacket(), null));
+        BedrockPacketWrapper queuedWrapper = testPeer.peer.packetQueue.peek();
+        assertNotNull(queuedWrapper);
+        testPeer.peer.schedulePacketFlush();
+        testPeer.channel.runPendingTasks();
+
+        assertTrue(testPeer.peer.packetQueue.isEmpty());
+        assertEquals(0, queuedWrapper.refCnt());
+        assertNull(testPeer.channel.readOutbound());
+        assertEquals(0, counter.flushes);
+        testPeer.channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void closeTearsDownAllSessionsDespiteSelfRemoval() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+        // Sessions remove themselves from the open addressing map during
+        // onClose(); these ids previously corrupted the iteration mid teardown.
+        for (int id : new int[]{0, 1, 33, 66}) {
+            testPeer.peer.sessions.put(id, new BedrockSession(testPeer.peer, id) {
+                @Override
+                public void disconnect(CharSequence reason, boolean hideReason) {
+                }
+            });
+        }
+        testPeer.peer.sendPacket(0, 0, new PlayStatusPacket());
+        BedrockPacketWrapper queuedWrapper = testPeer.peer.packetQueue.peek();
+
+        testPeer.channel.close();
+        testPeer.peer.onClose();
+
+        assertTrue(testPeer.peer.sessions.isEmpty());
+        assertTrue(testPeer.peer.packetQueue.isEmpty());
+        assertEquals(0, queuedWrapper.refCnt());
+        testPeer.channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void rejectedFlushScheduleRetriesUntilThePacketFlushes() {
+        FlushCounter counter = new FlushCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(counter);
+        channel.freezeTime();
+        RejectingPeer peer = new RejectingPeer(channel);
+        PlayStatusPacket packet = new PlayStatusPacket();
+
+        peer.rejectFlushSchedules = true;
+        peer.sendPacket(0, 0, packet);
+
+        assertFalse(peer.flushScheduled.get());
+        assertFalse(peer.packetQueue.isEmpty());
+        assertEquals(1, peer.retries.size());
+
+        // The retry re-enters the normal scheduling path once the loop accepts.
+        peer.rejectFlushSchedules = false;
+        peer.retries.remove(0).run();
+
+        channel.advanceTimeBy(BedrockPeer.BATCH_FLUSH_DELAY_NANOS, TimeUnit.NANOSECONDS);
+        channel.runScheduledPendingTasks();
+
+        assertOutboundPacket(channel, packet);
+        assertNull(channel.readOutbound());
+        assertTrue(peer.packetQueue.isEmpty());
+        assertFalse(peer.flushScheduled.get());
+        channel.close();
+        peer.onClose();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void rejectedOffLoopCloseRetriesUntilTheCloseLands() {
+        FlushCounter counter = new FlushCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(counter);
+        channel.freezeTime();
+        RejectingPeer peer = new RejectingPeer(channel);
+        BedrockSession session = new BedrockSession(peer, 0) {
+            @Override
+            public void disconnect(CharSequence reason, boolean hideReason) {
+            }
+        };
+        peer.sessions.put(0, session);
+
+        peer.rejectNextExecute = true;
+        peer.simulateOffLoop = true;
+        peer.close("Bye");
+
+        assertTrue(channel.isOpen());
+        assertNotEquals("Bye", session.disconnectReason);
+        assertEquals(1, peer.retries.size());
+
+        // In production the retry runs on the global executor, still off the
+        // loop, so it must submit close() to the event loop again.
+        peer.retries.remove(0).run();
+        assertNotEquals("Bye", session.disconnectReason);
+
+        peer.simulateOffLoop = false;
+        channel.runPendingTasks();
+
+        assertEquals("Bye", session.disconnectReason);
+        assertFalse(channel.isOpen());
+        peer.onClose();
+        channel.finishAndReleaseAll();
+    }
+
+    @Test
+    public void persistentRejectionKeepsExactlyOneRetryChain() {
+        FlushCounter counter = new FlushCounter();
+        EmbeddedChannel channel = new EmbeddedChannel(counter);
+        channel.freezeTime();
+        RejectingPeer peer = new RejectingPeer(channel);
+        peer.rejectFlushSchedules = true;
+
+        peer.sendPacket(0, 0, new PlayStatusPacket());
+        peer.sendPacket(0, 0, new PlayStatusPacket());
+        peer.sendPacket(0, 0, new PlayStatusPacket());
+        assertEquals(1, peer.retries.size());
+
+        // A retry that is itself rejected continues the chain without forking.
+        peer.retries.remove(0).run();
+        assertEquals(1, peer.retries.size());
+
+        peer.sendPacket(0, 0, new PlayStatusPacket());
+        assertEquals(1, peer.retries.size());
+
+        channel.close();
+        peer.onClose();
+        assertTrue(peer.packetQueue.isEmpty());
+        channel.finishAndReleaseAll();
+    }
+
     private static TestPeer createPeer(FlushCounter counter) {
         EmbeddedChannel channel = new EmbeddedChannel(counter);
         channel.freezeTime();
@@ -180,6 +360,48 @@ public class BedrockPeerBatchingTest {
                 this.peer.sendPacket(0, 0, this.packet);
             }
             super.flush(ctx);
+        }
+    }
+
+    private static final class RejectingPeer extends BedrockPeer {
+        final java.util.List<Runnable> retries = new java.util.ArrayList<>();
+        boolean rejectFlushSchedules;
+        boolean rejectNextExecute;
+        // EmbeddedEventLoop reports every thread as the loop thread, so the off
+        // loop branch is simulated instead of using a real second thread.
+        boolean simulateOffLoop;
+
+        RejectingPeer(EmbeddedChannel channel) {
+            super(channel, (peer, sessionId) -> {
+                throw new AssertionError("A session should not be created in this test");
+            });
+        }
+
+        @Override
+        void scheduleFlushTask() {
+            if (this.rejectFlushSchedules) {
+                throw new java.util.concurrent.RejectedExecutionException("rejected by test");
+            }
+            super.scheduleFlushTask();
+        }
+
+        @Override
+        void executeOnEventLoop(Runnable task) {
+            if (this.rejectNextExecute) {
+                this.rejectNextExecute = false;
+                throw new java.util.concurrent.RejectedExecutionException("rejected by test");
+            }
+            super.executeOnEventLoop(task);
+        }
+
+        @Override
+        boolean isOnEventLoop() {
+            return !this.simulateOffLoop && super.isOnEventLoop();
+        }
+
+        @Override
+        void scheduleRejectedRetry(Runnable retry) {
+            this.retries.add(retry);
         }
     }
 

--- a/bedrock-connection/src/test/java/org/cloudburstmc/protocol/bedrock/BedrockPeerBatchingTest.java
+++ b/bedrock-connection/src/test/java/org/cloudburstmc/protocol/bedrock/BedrockPeerBatchingTest.java
@@ -1,0 +1,195 @@
+package org.cloudburstmc.protocol.bedrock;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.ReferenceCountUtil;
+import org.cloudburstmc.protocol.bedrock.netty.BedrockPacketWrapper;
+import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
+import org.cloudburstmc.protocol.bedrock.packet.PlayStatusPacket;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BedrockPeerBatchingTest {
+
+    @Test
+    public void normalPacketsAreCoalescedForOneMillisecond() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+        PlayStatusPacket firstPacket = new PlayStatusPacket();
+        PlayStatusPacket secondPacket = new PlayStatusPacket();
+
+        try {
+            testPeer.peer.sendPacket(0, 0, firstPacket);
+            testPeer.peer.sendPacket(0, 0, secondPacket);
+
+            testPeer.channel.advanceTimeBy(BedrockPeer.BATCH_FLUSH_DELAY_NANOS - 1, TimeUnit.NANOSECONDS);
+            testPeer.channel.runScheduledPendingTasks();
+            assertNull(testPeer.channel.readOutbound());
+            assertEquals(0, counter.flushes);
+
+            testPeer.channel.advanceTimeBy(1, TimeUnit.NANOSECONDS);
+            testPeer.channel.runScheduledPendingTasks();
+
+            assertOutboundPacket(testPeer.channel, firstPacket);
+            assertOutboundPacket(testPeer.channel, secondPacket);
+            assertNull(testPeer.channel.readOutbound());
+            assertEquals(1, counter.flushes);
+            assertTrue(testPeer.peer.packetQueue.isEmpty());
+            assertFalse(testPeer.peer.flushScheduled.get());
+        } finally {
+            close(testPeer);
+        }
+    }
+
+    @Test
+    public void immediatePacketBypassesPendingBatch() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+        PlayStatusPacket queuedPacket = new PlayStatusPacket();
+        PlayStatusPacket immediatePacket = new PlayStatusPacket();
+
+        try {
+            testPeer.peer.sendPacket(0, 0, queuedPacket);
+            testPeer.peer.sendPacketImmediately(0, 0, immediatePacket);
+
+            assertOutboundPacket(testPeer.channel, immediatePacket);
+            assertNull(testPeer.channel.readOutbound());
+            assertEquals(1, counter.flushes);
+
+            advanceToFlush(testPeer.channel);
+
+            assertOutboundPacket(testPeer.channel, queuedPacket);
+            assertNull(testPeer.channel.readOutbound());
+            assertEquals(2, counter.flushes);
+        } finally {
+            close(testPeer);
+        }
+    }
+
+    @Test
+    public void packetEnqueuedDuringFlushSchedulesAnotherBatch() {
+        EnqueueOnFirstFlush handler = new EnqueueOnFirstFlush();
+        TestPeer testPeer = createPeer(handler);
+        PlayStatusPacket firstPacket = new PlayStatusPacket();
+        PlayStatusPacket secondPacket = new PlayStatusPacket();
+        handler.peer = testPeer.peer;
+        handler.packet = secondPacket;
+
+        try {
+            testPeer.peer.sendPacket(0, 0, firstPacket);
+            advanceToFlush(testPeer.channel);
+
+            assertOutboundPacket(testPeer.channel, firstPacket);
+            assertNull(testPeer.channel.readOutbound());
+            assertEquals(1, handler.flushes);
+            assertTrue(testPeer.peer.flushScheduled.get());
+
+            advanceToFlush(testPeer.channel);
+
+            assertOutboundPacket(testPeer.channel, secondPacket);
+            assertNull(testPeer.channel.readOutbound());
+            assertEquals(2, handler.flushes);
+            assertFalse(testPeer.peer.flushScheduled.get());
+        } finally {
+            close(testPeer);
+        }
+    }
+
+    @Test
+    public void closeReleasesQueuedPacketsAndPreventsScheduledWrite() {
+        FlushCounter counter = new FlushCounter();
+        TestPeer testPeer = createPeer(counter);
+        testPeer.peer.sendPacket(0, 0, new PlayStatusPacket());
+        BedrockPacketWrapper queuedWrapper = testPeer.peer.packetQueue.peek();
+
+        testPeer.channel.close();
+        testPeer.peer.onClose();
+
+        assertTrue(testPeer.peer.packetQueue.isEmpty());
+        assertEquals(0, queuedWrapper.refCnt());
+
+        advanceToFlush(testPeer.channel);
+
+        assertNull(testPeer.channel.readOutbound());
+        assertEquals(0, counter.flushes);
+        // flushScheduled is not asserted here: after close it is meaningless. On a
+        // live loop the pending task clears it in its closed branch, but
+        // EmbeddedChannel.close() cancels scheduled tasks so it stays set. Nothing
+        // reads it post close since the closed check precedes the CAS.
+        testPeer.channel.finishAndReleaseAll();
+    }
+
+    private static TestPeer createPeer(FlushCounter counter) {
+        EmbeddedChannel channel = new EmbeddedChannel(counter);
+        channel.freezeTime();
+        BedrockPeer peer = new BedrockPeer(channel, (ignoredPeer, ignoredSessionId) -> {
+            throw new AssertionError("A session should not be created in this test");
+        });
+        return new TestPeer(channel, peer);
+    }
+
+    private static void advanceToFlush(EmbeddedChannel channel) {
+        channel.advanceTimeBy(BedrockPeer.BATCH_FLUSH_DELAY_NANOS, TimeUnit.NANOSECONDS);
+        channel.runScheduledPendingTasks();
+    }
+
+    private static void assertOutboundPacket(EmbeddedChannel channel, BedrockPacket expectedPacket) {
+        BedrockPacketWrapper wrapper = channel.readOutbound();
+        assertNotNull(wrapper);
+        try {
+            assertSame(expectedPacket, wrapper.getPacket());
+        } finally {
+            ReferenceCountUtil.release(wrapper);
+        }
+    }
+
+    private static void close(TestPeer testPeer) {
+        testPeer.channel.close();
+        testPeer.peer.onClose();
+        testPeer.channel.finishAndReleaseAll();
+    }
+
+    private static class FlushCounter extends ChannelOutboundHandlerAdapter {
+        int flushes;
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) throws Exception {
+            this.flushes++;
+            ctx.flush();
+        }
+    }
+
+    private static final class EnqueueOnFirstFlush extends FlushCounter {
+        private BedrockPeer peer;
+        private BedrockPacket packet;
+        private boolean enqueued;
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) throws Exception {
+            if (!this.enqueued) {
+                this.enqueued = true;
+                this.peer.sendPacket(0, 0, this.packet);
+            }
+            super.flush(ctx);
+        }
+    }
+
+    private static final class TestPeer {
+        private final EmbeddedChannel channel;
+        private final BedrockPeer peer;
+
+        private TestPeer(EmbeddedChannel channel, BedrockPeer peer) {
+            this.channel = channel;
+            this.peer = peer;
+        }
+    }
+}


### PR DESCRIPTION
Outbound packets wait for a fixed 50 ms flush tick, which adds 0 to 50 ms to every batch when the packet producer is not a local game loop (proxies, standalone tools). Packets are now flushed 1 ms after enqueueing, so the wait is bounded by ~1 ms plus timer granularity, while batching, compression, and reliability behavior stay as they are.

Notes for review:

- With `RAK_AUTO_FLUSH` on (the default), the RakNet layer ignores explicit flushes: datagram cadence stays on the existing 10 ms session tick, and the worst case wait still drops from ~60 ms to ~10 ms. Setting `RAK_AUTO_FLUSH=false` gives the full on demand path.
- For a tick aligned server, sends spread over more than 1 ms within a tick compress as a few smaller batches instead of one; datagram counts are unchanged under auto flush. `sendPacketImmediately()` is unchanged.
- Checked Cloudburst Server, ProxyPass, BedrockConnect, and Geyser: none set `RAK_AUTO_FLUSH` or override the affected code.
- Per packet flushing (no coalescing window) was considered and decided against, since it costs 3.4x the bandwidth for under 1 ms of further gain.

Results: in my own testing on Velocity with Geyser (`RAK_AUTO_FLUSH=false`), backend measured player ping dropped from 50-100 ms to 20-45 ms. Combined with separate Geyser side changes that make its ping measurement more accurate, essentially every user who tested the release reported noticeably better ping.
