### PR TITLE
Allocate BedrockPacketWrapper#flags lazily

### DIFF
--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/BedrockBatchWrapper.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/BedrockBatchWrapper.java
@@ -77,8 +77,8 @@ public class BedrockBatchWrapper extends AbstractReferenceCounted {
         this.packets.add(wrapper);
         this.modify();
 
-        if (!wrapper.getFlags().isEmpty()) {
-            for (PacketFlag flag : wrapper.getFlags()) {
+        if (wrapper.getFlagsRaw() != null && !wrapper.getFlagsRaw().isEmpty()) {
+            for (PacketFlag flag : wrapper.getFlagsRaw()) {
                 if (flag.canInherit()) {
                     this.flags.add(flag);
                 }

--- a/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/BedrockPacketWrapper.java
+++ b/bedrock-connection/src/main/java/org/cloudburstmc/protocol/bedrock/netty/BedrockPacketWrapper.java
@@ -7,6 +7,7 @@ import io.netty.util.internal.ObjectPool;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.cloudburstmc.protocol.bedrock.packet.BedrockPacket;
 import org.cloudburstmc.protocol.bedrock.util.PacketFlag;
 
@@ -24,7 +25,7 @@ public class BedrockPacketWrapper extends AbstractReferenceCounted {
     private int headerLength;
     private BedrockPacket packet;
     private ByteBuf packetBuffer;
-    private Set<PacketFlag> flags = new ObjectOpenHashSet<>();
+    private Set<PacketFlag> flags;
 
     public static BedrockPacketWrapper create(int packetId, int senderSubClientId, int targetSubClientId, BedrockPacket packet, ByteBuf packetBuffer) {
         BedrockPacketWrapper wrapper = RECYCLER.get();
@@ -56,16 +57,33 @@ public class BedrockPacketWrapper extends AbstractReferenceCounted {
         this.handle = handle;
     }
 
+    public Set<PacketFlag> getFlags() {
+        if (this.flags == null) {
+            this.flags = new ObjectOpenHashSet<>();
+        }
+        return flags;
+    }
+
+    @Nullable
+    public Set<PacketFlag> getFlagsRaw() {
+        return this.flags;
+    }
+
     public void setFlag(PacketFlag flag) {
+        if (this.flags == null) {
+            this.flags = new ObjectOpenHashSet<>();
+        }
         this.flags.add(flag);
     }
 
     public boolean hasFlag(PacketFlag flag) {
-        return this.flags.contains(flag);
+        return this.flags != null && this.flags.contains(flag);
     }
 
     public void unsetFlag(PacketFlag flag) {
-        this.flags.remove(flag);
+        if (this.flags != null) {
+            this.flags.remove(flag);
+        }
     }
 
     @Override
@@ -78,7 +96,9 @@ public class BedrockPacketWrapper extends AbstractReferenceCounted {
         this.headerLength = 0;
         this.packet = null;
         this.packetBuffer = null;
-        this.flags.clear();
+        if (this.flags != null) {
+            this.flags.clear();
+        }
         this.handle.recycle(this);
     }
 


### PR DESCRIPTION
On profiling I noticed that if you bust the limit of the recycler,
the allocation of this collection becomes a noticable allocation
pressure point on pool misses when constructing this packet
