### PR TITLE
Fix command parameter type mapping

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v975/Bedrock_v975.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v975/Bedrock_v975.java
@@ -26,9 +26,9 @@ public class Bedrock_v975 extends Bedrock_v944 {
     protected static final TypeMap<CommandParam> COMMAND_PARAMS = TypeMap.builder(CommandParam.class)
             .insert(0, CommandParam.UNKNOWN)
             .insert(1, CommandParam.INT)
-            .insert(2, CommandParam.FLOAT)
-            .insert(3, CommandParam.VALUE)
-            .insert(4, CommandParam.R_VALUE)
+            // ID 2 is unused on the wire.
+            .insert(3, CommandParam.FLOAT)
+            .insert(4, CommandParam.VALUE)
             .insert(5, CommandParam.WILDCARD_INT)
             .insert(6, CommandParam.OPERATOR)
             .insert(7, CommandParam.COMPARE_OPERATOR)

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v975/Bedrock_v975.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v975/Bedrock_v975.java
@@ -28,7 +28,7 @@ public class Bedrock_v975 extends Bedrock_v944 {
             .insert(1, CommandParam.INT)
             // ID 2 is unused on the wire.
             .insert(3, CommandParam.FLOAT)
-            .insert(4, CommandParam.VALUE)
+            .insert(4, CommandParam.R_VALUE)
             .insert(5, CommandParam.WILDCARD_INT)
             .insert(6, CommandParam.OPERATOR)
             .insert(7, CommandParam.COMPARE_OPERATOR)


### PR DESCRIPTION
## Summary

- reserve command parameter type ID `2`, which is unused on the wire
- map `FLOAT` to ID `3` and `R_VALUE` to ID `4`
- remove the obsolete `VALUE` packet mapping

## Why

The command parameter table was shifted relative to the `AvailableCommandsPacket` emitted by current Bedrock versions. The correct IDs are:

- `INT`: `1`
- `FLOAT`: `3`
- `R_VALUE`: `4`
- `WILDCARD_INT`: `5`

`R_VALUE` is backed by the relative-float parser and is used by commands such as `/tp` for rotation values. ID `2` is unused, and `VALUE` is not registered as a basic parameter type.

This corrects both decoding, where parameter types were interpreted as the following enum member, and encoding, where floats were written using the unused ID `2`.

Closes #346.
