### PR TITLE
Fix PlayerLocationPacket type serialization for v2168

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/serializer/PlayerLocationSerializer_v2168.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v2168/serializer/PlayerLocationSerializer_v2168.java
@@ -15,7 +15,7 @@ public class PlayerLocationSerializer_v2168 extends PlayerLocationSerializer_v80
         VarInts.writeLong(buffer, packet.getTargetEntityId());
         VarInts.writeUnsignedInt(buffer, packet.getType().ordinal());
 
-        VarInts.writeInt(buffer, 0);
+        VarInts.writeInt(buffer, packet.getType().ordinal());
 
         if (packet.getType() == PlayerLocationPacket.Type.COORDINATES) {
             helper.writeVector3f(buffer, packet.getPosition());


### PR DESCRIPTION
* the type is sent as varint immediately after the control value type unsigned varint