### PR TITLE
Support double and list dynamic values in ClientboundDataStorePacket

### DIFF
--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/ClientboundDataStoreSerializer_v898.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/ClientboundDataStoreSerializer_v898.java
@@ -187,7 +187,9 @@ public class ClientboundDataStoreSerializer_v898 implements BedrockPacketSeriali
                 return helper.readString(buffer);
             case 5:
                 int length = VarInts.readUnsignedInt(buffer);
-                List<Object> items = new ArrayList<>(length);
+                // Each entry carries at least a 4-byte type tag, so cap the pre-sizing by what the
+                // buffer can actually hold instead of trusting the length prefix with an allocation.
+                List<Object> items = new ArrayList<>(Math.min(length, buffer.readableBytes() / 4));
                 for (int i = 0; i < length; i++) {
                     items.add(readDataStoreChange(buffer, helper));
                 }

--- a/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/ClientboundDataStoreSerializer_v898.java
+++ b/bedrock-codec/src/main/java/org/cloudburstmc/protocol/bedrock/codec/v898/serializer/ClientboundDataStoreSerializer_v898.java
@@ -11,7 +11,9 @@ import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreUpdate;
 import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataStorePacket;
 import org.cloudburstmc.protocol.common.util.VarInts;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -112,8 +114,27 @@ public class ClientboundDataStoreSerializer_v898 implements BedrockPacketSeriali
         }));
     }
 
+    /**
+     * The dynamic value is a {@code cereal::DynamicValue} variant; the type tag is the
+     * alternative index: 0 null, 1 bool, 2 int64, 3 double, 4 string, 5 list, 6 map.
+     */
     protected void writeDataStoreChange(ByteBuf buffer, BedrockCodecHelper helper, Object value) {
-        int type = value instanceof Boolean ? 1 : value instanceof Number ? 2 : value instanceof String ? 4 : value instanceof Map ? 6 : 0;
+        int type;
+        if (value instanceof Boolean) {
+            type = 1;
+        } else if (value instanceof Double || value instanceof Float) {
+            type = 3;
+        } else if (value instanceof Number) {
+            type = 2;
+        } else if (value instanceof String) {
+            type = 4;
+        } else if (value instanceof List) {
+            type = 5;
+        } else if (value instanceof Map) {
+            type = 6;
+        } else {
+            type = 0;
+        }
 
         buffer.writeIntLE(type);
 
@@ -126,8 +147,17 @@ public class ClientboundDataStoreSerializer_v898 implements BedrockPacketSeriali
             case 2:
                 buffer.writeLongLE(((Number) value).longValue());
                 break;
+            case 3:
+                buffer.writeDoubleLE(((Number) value).doubleValue());
+                break;
             case 4:
                 helper.writeString(buffer, (String) value);
+                break;
+            case 5:
+                VarInts.writeUnsignedInt(buffer, ((List<?>) value).size());
+                for (Object item : (List<?>) value) {
+                    writeDataStoreChange(buffer, helper, item);
+                }
                 break;
             case 6:
                 VarInts.writeUnsignedInt(buffer, ((Map<?, ?>) value).size());
@@ -151,8 +181,17 @@ public class ClientboundDataStoreSerializer_v898 implements BedrockPacketSeriali
                 return buffer.readBoolean();
             case 2:
                 return buffer.readLongLE();
+            case 3:
+                return buffer.readDoubleLE();
             case 4:
                 return helper.readString(buffer);
+            case 5:
+                int length = VarInts.readUnsignedInt(buffer);
+                List<Object> items = new ArrayList<>(length);
+                for (int i = 0; i < length; i++) {
+                    items.add(readDataStoreChange(buffer, helper));
+                }
+                return items;
             case 6:
                 int size = VarInts.readUnsignedInt(buffer);
                 Map<String, Object> values = new LinkedHashMap<>();

--- a/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/DataStoreSerializationTest.java
+++ b/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/DataStoreSerializationTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class DataStoreSerializationTest {
 
@@ -62,6 +63,27 @@ public class DataStoreSerializationTest {
         assertEquals(1.5d, roundTrip(1.5d));
         assertEquals("text", roundTrip("text"));
         assertEquals(Arrays.asList(1L, 2.5d, "three"), roundTrip(Arrays.asList(1L, 2.5d, "three")));
+    }
+
+    @Test
+    public void testHostileListLengthDoesNotPreAllocate() {
+        // A forged length prefix must not translate into an up-front allocation; the loop then
+        // fails on buffer underflow instead of exhausting memory.
+        ByteBuf buffer = Unpooled.buffer();
+        VarInts.writeUnsignedInt(buffer, 1); // update count
+        VarInts.writeUnsignedInt(buffer, 1); // action type: change
+        HELPER.writeString(buffer, "minecraft");
+        HELPER.writeString(buffer, "custom_form_data_1");
+        buffer.writeIntLE(1); // property update count
+        buffer.writeIntLE(5); // list tag
+        VarInts.writeUnsignedInt(buffer, Integer.MAX_VALUE);
+        try {
+            ClientboundDataStorePacket decoded = new ClientboundDataStorePacket();
+            assertThrows(Exception.class,
+                    () -> ClientboundDataStoreSerializer_v924.INSTANCE.deserialize(buffer, HELPER, decoded));
+        } finally {
+            buffer.release();
+        }
     }
 
     @Test

--- a/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/DataStoreSerializationTest.java
+++ b/bedrock-codec/src/test/java/org/cloudburstmc/protocol/bedrock/test/DataStoreSerializationTest.java
@@ -1,0 +1,118 @@
+package org.cloudburstmc.protocol.bedrock.test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.cloudburstmc.protocol.bedrock.codec.BedrockCodecHelper;
+import org.cloudburstmc.protocol.bedrock.codec.v924.Bedrock_v924;
+import org.cloudburstmc.protocol.bedrock.codec.v924.serializer.ClientboundDataStoreSerializer_v924;
+import org.cloudburstmc.protocol.bedrock.data.datastore.DataStoreChange;
+import org.cloudburstmc.protocol.bedrock.packet.ClientboundDataStorePacket;
+import org.cloudburstmc.protocol.common.util.VarInts;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class DataStoreSerializationTest {
+
+    private static final BedrockCodecHelper HELPER = Bedrock_v924.CODEC.createHelper();
+
+    @Test
+    public void testDynamicValueRoundTrip() {
+        // A custom_form-shaped seed exercising every tag type at once.
+        Map<String, Object> slot = new LinkedHashMap<>();
+        slot.put("slider_visible", true);
+        slot.put("label", "Slider");
+        slot.put("value", 5.0d);
+        slot.put("minValue", 0.0d);
+        slot.put("maxValue", 10.0d);
+
+        Map<String, Object> label = new LinkedHashMap<>();
+        label.put("label_visible", true);
+        label.put("text", Collections.singletonMap("rawtext",
+                Arrays.asList(Collections.singletonMap("translate", "gui.ok"))));
+
+        Map<String, Object> layout = new LinkedHashMap<>();
+        layout.put("0", slot);
+        layout.put("1", label);
+        layout.put("length", 2L);
+
+        Map<String, Object> tree = new LinkedHashMap<>();
+        tree.put("title", "Round trip");
+        tree.put("layout", layout);
+        tree.put("empty", null);
+
+        assertEquals(tree, roundTrip(tree));
+    }
+
+    @Test
+    public void testNullDynamicValueRoundTrip() {
+        assertNull(roundTrip(null));
+    }
+
+    @Test
+    public void testScalarDynamicValueRoundTrip() {
+        assertEquals(true, roundTrip(true));
+        assertEquals(42L, roundTrip(42L));
+        assertEquals(1.5d, roundTrip(1.5d));
+        assertEquals("text", roundTrip("text"));
+        assertEquals(Arrays.asList(1L, 2.5d, "three"), roundTrip(Arrays.asList(1L, 2.5d, "three")));
+    }
+
+    @Test
+    public void testDynamicValueTypeTags() {
+        // A symmetric round trip would not catch swapped tags, so pin the values on the wire.
+        assertEquals(0, writtenTypeTag(null));
+        assertEquals(1, writtenTypeTag(true));
+        assertEquals(2, writtenTypeTag(42L));
+        assertEquals(3, writtenTypeTag(1.5d));
+        assertEquals(4, writtenTypeTag("text"));
+        assertEquals(5, writtenTypeTag(Arrays.asList("a", "b")));
+        assertEquals(6, writtenTypeTag(Collections.singletonMap("key", "value")));
+    }
+
+    private Object roundTrip(Object value) {
+        ByteBuf buffer = serialize(value);
+        try {
+            ClientboundDataStorePacket decoded = new ClientboundDataStorePacket();
+            ClientboundDataStoreSerializer_v924.INSTANCE.deserialize(buffer, HELPER, decoded);
+            return ((DataStoreChange) decoded.getUpdates().get(0)).getNewValue();
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private int writtenTypeTag(Object value) {
+        ByteBuf buffer = serialize(value);
+        try {
+            VarInts.readUnsignedInt(buffer); // update count
+            VarInts.readUnsignedInt(buffer); // action type
+            HELPER.readString(buffer); // data store name
+            HELPER.readString(buffer); // property
+            buffer.readIntLE(); // property update count
+            return buffer.readIntLE();
+        } finally {
+            buffer.release();
+        }
+    }
+
+    private ByteBuf serialize(Object value) {
+        DataStoreChange change = new DataStoreChange();
+        change.setDataStoreName("minecraft");
+        change.setProperty("custom_form_data_1");
+        change.setUpdateCount(1);
+        change.setNewValue(value);
+
+        ClientboundDataStorePacket packet = new ClientboundDataStorePacket();
+        packet.getUpdates().add(change);
+
+        ByteBuf buffer = Unpooled.buffer();
+        ClientboundDataStoreSerializer_v924.INSTANCE.serialize(buffer, HELPER, packet);
+        return buffer;
+    }
+}


### PR DESCRIPTION
The `DataStoreChange` dynamic value is a `cereal::DynamicValue` variant tagged by alternative index: 0 null, 1 bool, 2 int64, 3 double, 4 string, 5 list, 6 map. Tags 3 and 5 were unhandled and threw `IllegalStateException`, dropping the packet. Vanilla writes every non-integer number as a double and rawtext as a list, so all 1.26.40 data-driven form seeds failed to decode.

Verified both directions against BDS 1.26.40.8; the tag order matches BDS symbols and the gophertunnel/pmmp implementations.
